### PR TITLE
feat(ui): replace radar particles with pulse rings and add tooltips

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -82,7 +82,9 @@ function updateUI(): void {
           'aria-hidden': 'true',
         }),
         createElement('div', { class: 'session-info' }, [
-          createElement('div', { class: 'session-id' }, [s.session_id.slice(0, 12) + '...']),
+          createElement('div', { class: 'session-id', title: s.session_id }, [
+            s.session_id.slice(0, 12) + '...',
+          ]),
           createElement('div', { class: 'session-meta' }, [
             `${s.machine_id || 'Unknown'} • ${s.event_count || 0} events`,
           ]),

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -44,12 +44,13 @@ export interface Position {
   y: number
 }
 
-export interface Particle {
+export interface PulseRing {
   x: number
   y: number
-  vx: number
-  vy: number
-  size: number
+  radius: number
+  growthRate: number
+  maxRadius: number
+  lineWidth: number
   color: string
   alpha: number
   lifetime: number

--- a/client/src/visualizer.ts
+++ b/client/src/visualizer.ts
@@ -1,4 +1,4 @@
-import type { EnrichedEvent, Session, Particle, Position } from './types'
+import type { EnrichedEvent, Session, PulseRing, Position } from './types'
 import type { AudioEngine } from './audio-engine'
 
 // ============================================
@@ -147,6 +147,7 @@ export class SourceOverlay {
     const el = document.createElement('div')
     el.className = 'source-circle'
     el.dataset.session = key
+    el.title = session.session_id || 'Unknown session'
     el.style.setProperty('--session-color', session.color)
 
     // Icon and label
@@ -321,7 +322,7 @@ export class SourceOverlay {
 export class Visualizer {
   private canvas: HTMLCanvasElement
   private ctx: CanvasRenderingContext2D
-  private particles: Particle[] = []
+  private pulses: PulseRing[] = []
   private sessions = new Map<string, Session>()
   private animationId: number | null = null
   private isAnimating = false
@@ -334,6 +335,7 @@ export class Visualizer {
 
   // Fixed font string to avoid CSS variable in canvas (which doesn't work)
   private readonly FONT = "10px 'SF Mono', Monaco, Inconsolata, 'Roboto Mono', monospace"
+  private readonly MAX_ACTIVE_PULSES = 180
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
@@ -414,7 +416,7 @@ export class Visualizer {
     const { color, event_type, tool_name } = event
     const { centerX, centerY, maxRadius } = this.getRadarGeometry()
 
-    // Get particle spawn position from source overlay or fallback to center
+    // Get pulse origin from source overlay or fallback to center
     let x = centerX
     let y = centerY
 
@@ -427,29 +429,49 @@ export class Visualizer {
       }
     }
 
-    // Particle properties based on event
-    let size = 20
-    let lifetime = 60
+    // Pulse properties based on event type
+    let baseRadius = 10
+    let growthRate = 2
+    let maxPulseRadius = 64
+    let lifetime = 36
+    let lineWidth = 2
+    let pulseCount = 1
 
     if (event_type === 'Stop') {
-      size = 50
-      lifetime = 120
+      baseRadius = 14
+      growthRate = 2.4
+      maxPulseRadius = 110
+      lifetime = 56
+      lineWidth = 3
+      pulseCount = 2
     } else if (event_type === 'PreToolUse' || event_type === 'PostToolUse') {
-      size = tool_name === 'Task' ? 35 : 15
-      lifetime = 45
+      baseRadius = tool_name === 'Task' ? 12 : 8
+      growthRate = tool_name === 'Task' ? 2.2 : 1.7
+      maxPulseRadius = tool_name === 'Task' ? 88 : 52
+      lifetime = tool_name === 'Task' ? 44 : 30
+      lineWidth = tool_name === 'Task' ? 2.6 : 1.8
     }
 
-    this.particles.push({
-      x,
-      y,
-      vx: (Math.random() - 0.5) * 2,
-      vy: (Math.random() - 0.5) * 2,
-      size,
-      color: color || '#4ECDC4',
-      alpha: 1,
-      lifetime,
-      maxLifetime: lifetime,
-    })
+    for (let i = 0; i < pulseCount; i++) {
+      const lifetimeOffset = i * 6
+      this.pulses.push({
+        x,
+        y,
+        radius: baseRadius + i * 4,
+        growthRate,
+        maxRadius: maxPulseRadius,
+        lineWidth,
+        color: color || '#4ECDC4',
+        alpha: 1,
+        lifetime: Math.max(8, lifetime - lifetimeOffset),
+        maxLifetime: Math.max(8, lifetime - lifetimeOffset),
+      })
+    }
+
+    // Avoid unbounded growth under bursty event streams
+    if (this.pulses.length > this.MAX_ACTIVE_PULSES) {
+      this.pulses = this.pulses.slice(-this.MAX_ACTIVE_PULSES)
+    }
 
     // Start animation if not running
     if (!this.isAnimating) {
@@ -485,50 +507,42 @@ export class Visualizer {
 
     const { ctx } = this
 
-    // Clear with fade effect
-    ctx.fillStyle = 'rgba(0, 20, 31, 0.15)'
-    ctx.fillRect(0, 0, this.width, this.height)
-
-    // Redraw radar grid (faint, under particles)
+    // Redraw static radar first, then animated pulse rings
     this.drawRadarGrid()
 
-    // Update and draw particles
-    let activeParticles = 0
-    this.particles = this.particles.filter((p) => {
+    let activePulses = 0
+    this.pulses = this.pulses.filter((p) => {
       p.lifetime--
       if (p.lifetime <= 0) return false
 
-      activeParticles++
+      p.radius += p.growthRate
+      if (p.radius > p.maxRadius) return false
+
       p.alpha = p.lifetime / p.maxLifetime
-      p.x += p.vx
-      p.y += p.vy
-      p.size *= 0.98
+      activePulses++
 
-      const alphaHex = Math.floor(p.alpha * 255)
-        .toString(16)
-        .padStart(2, '0')
-
-      // Glow effect (drawn first, behind main circle)
+      // Outer glow ring
+      ctx.save()
       ctx.beginPath()
-      ctx.arc(p.x, p.y, p.size * 1.5, 0, Math.PI * 2)
-      ctx.fillStyle =
-        p.color +
-        Math.floor(p.alpha * 50)
-          .toString(16)
-          .padStart(2, '0')
-      ctx.fill()
+      ctx.arc(p.x, p.y, p.radius, 0, Math.PI * 2)
+      ctx.strokeStyle = p.color
+      ctx.lineWidth = p.lineWidth * 1.8
+      ctx.globalAlpha = p.alpha * 0.35
+      ctx.stroke()
 
-      // Main particle
+      // Primary ring
       ctx.beginPath()
-      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2)
-      ctx.fillStyle = p.color + alphaHex
-      ctx.fill()
+      ctx.arc(p.x, p.y, p.radius, 0, Math.PI * 2)
+      ctx.lineWidth = p.lineWidth
+      ctx.globalAlpha = p.alpha
+      ctx.stroke()
+      ctx.restore()
 
       return true
     })
 
-    // Stop animation when no particles
-    if (activeParticles === 0) {
+    // Stop animation when no pulses
+    if (activePulses === 0) {
       this.stopAnimation()
       return
     }


### PR DESCRIPTION
## Summary
- Replace radar event particles with pulse-ring animations that expand outward and fade.
- Add native `title` tooltips to radar source circles so full session IDs are visible despite truncation.
- Add native `title` tooltips to Active Sessions item titles (`.session-id`) for full-name inspection.
- Keep existing truncation and layout behavior unchanged.

## Why
Long session names were heavily truncated in both radar and Active Sessions views, making them hard to parse quickly.

## Key Decisions
- Kept all changes in existing ownership boundaries:
  - `client/src/visualizer.ts` for radar animation + source overlay behavior
  - `client/src/main.ts` for Active Sessions rendering
- Replaced particle model with deterministic pulse-ring model (`PulseRing`) to simplify visuals.
- Added a pulse cap (`MAX_ACTIVE_PULSES`) to avoid unbounded queue growth under bursty streams.

## Testing
### Automated
- `npm run build:client`
- `cd client && bunx tsc --noEmit`

### Manual
- Started server and streamed events via `./test-events.sh`
- Verified:
  - pulse rings originate from source position when session is known
  - pulse rings fall back to center when needed
  - radar circles show tooltip with full session ID
  - active session title shows tooltip with full session ID

## Post-Deploy Monitoring & Validation
- **What to monitor/search**
  - Logs: browser console for client-side rendering errors (manual check)
  - Metrics/Dashboards: none (UI-only canvas/DOM behavior change)
- **Validation checks (queries/commands)**
  - `bun run start --port 3334`
  - `./test-events.sh`
  - Confirm pulses render and tooltips show full session IDs in UI
- **Expected healthy behavior**
  - Event feedback appears as expanding/fading pulse rings
  - No animation freeze/stuck rendering loops
  - Tooltip full IDs visible on hover in both radar + session list
- **Failure signal(s) / rollback trigger**
  - Missing event visuals, heavy animation jank, or missing tooltip attributes
  - Immediate action: rollback this PR and restore previous visualizer behavior
- **Validation window & owner**
  - Window: first interactive session after deploy
  - Owner: PR author
- **If no operational impact**
  - `No additional operational monitoring required: change is client-side UI-only with no server, schema, or external dependency impact.`

## Before / After Screenshots
| Before | After |
|--------|-------|
| ![before](https://files.catbox.moe/xq0h0s.png) | ![after](https://files.catbox.moe/5a8m73.png) |

### Pulse Effect (after)
![pulse-after](https://files.catbox.moe/l6njhk.png)

## Plan
- `docs/plans/2026-02-27-feat-replace-radar-particles-with-pulse-tooltips-plan.md`

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)
