### PR TITLE
feat(events): full Claude hook baseline + normalization hardening

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -2,72 +2,75 @@
 
 This file is the canonical event-coverage reference for bingbong.
 
-If event hooks/mappings change, update this file in the same PR. Keep the README concise and link here instead of duplicating large event tables.
+If event hooks/mappings change, update this file in the same PR.
+README should stay concise and link here.
 
 ## Baseline: Claude Code
 
-Claude Code is the baseline hook event source for bingbong.
+Claude Code is bingbong’s baseline harness.
 
-`bingbong install-hooks claude` installs the following event set from `src/install-hooks.ts` (`CLAUDE_EVENTS`):
+`bingbong install-hooks claude` installs the full current Claude hook set from `src/events.ts` (`CLAUDE_HOOK_EVENT_SPECS`), including matcher-aware config behavior.
 
-| Claude event | Installed by `install-hooks claude` | Matcher written by installer | Current runtime handling |
+### Claude hook install matrix
+
+Matcher installer behavior:
+- `matcher: ".*"` is written **only** for events that support matchers.
+- `matcher` is **omitted** for events that do not support matchers.
+
+| Claude event | Matcher support (Claude docs) | Installer writes matcher? | Current runtime handling |
 | --- | --- | --- | --- |
-| `PreToolUse` | Yes | `.*` | Tool-aware sound mapping (`tool_name`) |
-| `PostToolUse` | Yes | `.*` | Tool-aware sound mapping (`tool_name`) |
-| `SessionStart` | Yes | `""` | Dedicated event sound |
-| `SessionEnd` | Yes | `""` | Dedicated event sound |
-| `Stop` | Yes | `""` | Dedicated event sound |
-| `SubagentStop` | Yes | `""` | Dedicated event sound |
-| `PermissionRequest` | Yes | `""` | Emitted/logged; currently uses default fallback sound |
-| `Notification` | Yes | `""` | Emitted/logged; currently uses default fallback sound |
-| `PreCompact` | Yes | `""` | Dedicated event sound |
-| `Setup` | Yes | `""` | Emitted/logged; currently uses default fallback sound |
-| `UserPromptSubmit` | Yes | `""` | Emitted/logged; currently uses default fallback sound |
+| `SessionStart` | Yes | Yes (`.*`) | Dedicated event sound |
+| `UserPromptSubmit` | No | No | Dedicated event sound |
+| `PreToolUse` | Yes | Yes (`.*`) | Tool-aware sound mapping (`tool_name`) |
+| `PermissionRequest` | Yes | Yes (`.*`) | Dedicated high-priority sound |
+| `PostToolUse` | Yes | Yes (`.*`) | Tool-aware sound mapping (`tool_name`) |
+| `PostToolUseFailure` | Yes | Yes (`.*`) | Tool-aware failure variant (sharper timbre) |
+| `Notification` | Yes | Yes (`.*`) | Dedicated event sound |
+| `SubagentStart` | Yes | Yes (`.*`) | Dedicated event sound |
+| `SubagentStop` | Yes | Yes (`.*`) | Dedicated event sound |
+| `Stop` | No | No | Dedicated completion sound |
+| `TeammateIdle` | No | No | Dedicated low-intensity sound |
+| `TaskCompleted` | No | No | Dedicated completion sound |
+| `InstructionsLoaded` | No | No | Dedicated event sound |
+| `ConfigChange` | Yes | Yes (`.*`) | Dedicated event sound |
+| `WorktreeCreate` | No | No | Dedicated event sound |
+| `WorktreeRemove` | No | No | Dedicated event sound |
+| `PreCompact` | Yes | Yes (`.*`) | Dedicated event sound |
+| `PostCompact` | Yes | Yes (`.*`) | Dedicated event sound |
+| `Elicitation` | Yes | Yes (`.*`) | Dedicated high-priority sound |
+| `ElicitationResult` | Yes | Yes (`.*`) | Dedicated event sound |
+| `SessionEnd` | Yes | Yes (`.*`) | Dedicated event sound |
 
-### Claude TODO gaps (known)
+## Normalization + mapping path
 
-Current Claude install coverage is **not yet full parity** with the latest upstream Claude hook list.
+Primary normalization lives in `src/events.ts` and is applied in:
+- `src/emit.ts` (CLI hook ingest)
+- `src/server.ts` (defensive normalization for all `/events` input)
 
-- `Setup` is currently installed but is flagged as outdated in issue #13 notes.
-- Missing Claude events called out in issue #13:
-  - `PostToolUseFailure`
-  - `SubagentStart`
-  - `TeammateIdle`
-  - `TaskCompleted`
-  - `InstructionsLoaded`
-  - `ConfigChange`
-  - `WorktreeCreate`
-  - `WorktreeRemove`
-  - `PostCompact`
-  - `Elicitation`
-  - `ElicitationResult`
+Behavior:
+- Known harness-native aliases are normalized to Claude baseline names.
+- Original names are preserved via `tool_output.original_event_type` when mapped.
+- Missing/partial payload fields are defaulted safely (`session_id`, `tool_input`, `tool_output`, etc.) to avoid crashes.
 
-## Matcher caveats (Claude)
+## Cross-harness status (Claude baseline parity)
 
-- bingbong currently writes a `matcher` field for all installed Claude events.
-- `PreToolUse`/`PostToolUse` use `.*` intentionally.
-- For non-tool events, installer currently writes `matcher: ""`.
-- Per Claude docs (see issue #13), at least `Stop` and `UserPromptSubmit` ignore matchers; matcher values there are effectively no-ops.
+| Harness | Current emission model | Baseline alignment status |
+| --- | --- | --- |
+| Claude Code | Emits official Claude event names via `bingbong emit <EventType>` | Full baseline install coverage |
+| Cursor | Installs Cursor-native hook names, normalized in `emit/server` to Claude baseline where possible | Partial parity; core lifecycle/tool flow normalized |
+| OpenCode | Plugin maps core events to baseline and passes through additional OpenCode events | Core parity plus passthrough extras |
+| Pi | Extension maps core events; server normalization also maps compact-related aliases | Core parity plus passthrough extras |
 
-## Cross-harness mapping/status (practical)
+### Intentional gaps / follow-ups
 
-| Harness | Current event emission model | Mapping to Claude baseline | Practical status |
-| --- | --- | --- | --- |
-| Claude Code | Hook commands emit Claude event names directly via `bingbong emit <EventType>` | Native baseline names | Best coverage today (installed set above), but still has known TODO gaps. |
-| Cursor | Hook commands emit Cursor-native event names (`beforeShellExecution`, `afterMCPExecution`, etc.) | No normalization layer yet | Partial parity. Core lifecycle/tool moments are present, but names remain Cursor-native and not 1:1 Claude-normalized. |
-| OpenCode | Plugin emits OpenCode events from `agents/opencode/plugins/bingbong.js` | Maps core events (`tool.execute.before/after`, `session.created/deleted/idle/error`) to Claude-style names; passes through others | Good baseline parity for tool/session core, with extra OpenCode events preserved as raw names. |
-| Pi | Extension emits Pi events from `agents/pi/extensions/bingbong.ts` | Maps `tool_call`, `tool_result`, `session_start`, `session_shutdown`, `agent_end`; passes through other Pi events | Core parity is covered; broader Pi lifecycle events are currently Pi-native passthrough events. |
-
-### Cursor practical equivalence notes
-
-Current Cursor hooks install these events (`CURSOR_EVENTS` in `src/install-hooks.ts`):
-
-- `beforeShellExecution`, `beforeMCPExecution`, `beforeReadFile` → roughly `PreToolUse`-like
-- `afterShellExecution`, `afterMCPExecution`, `afterFileEdit` → roughly `PostToolUse`-like
-- `beforeSubmitPrompt` → roughly `UserPromptSubmit`-like
-- `afterAgentResponse`, `afterAgentThought` → notification-like lifecycle signals
-- `stop` → stop/completion signal (note lowercase Cursor naming)
+These are intentionally not claimed as full parity today:
+- Cursor/OpenCode/Pi do not expose 1:1 equivalents for every Claude lifecycle event.
+- Some non-Claude native events are preserved as passthrough names (kept for observability rather than dropped).
+- No strict schema validation/rejection on `/events`; normalization is permissive and best-effort by design.
 
 ## Maintenance note
 
-This file is the **source of truth** for bingbong event coverage documentation.
+When adding/removing events or changing mapping behavior:
+1. Update `src/events.ts`.
+2. Update this file in the same PR.
+3. Keep README concise and point here.

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ Each agent has hooks that fire on tool use, session start/stop, and other events
 
 ## Event Coverage
 
-Claude Code is bingbong's baseline hook event source.
+Claude Code is bingbong's baseline harness. `install-hooks claude` installs the full current official Claude hook event set.
 
-For the authoritative event coverage matrix (installed Claude events, known TODO gaps, Cursor/OpenCode/Pi mapping status, and matcher caveats), see [EVENTS.md](./EVENTS.md).
+For the authoritative event coverage matrix (installed Claude events, matcher behavior, and Cursor/OpenCode/Pi mapping status), see [EVENTS.md](./EVENTS.md).
 
 Cross-harness parity varies today; non-Claude harnesses may emit native event names or mapped subsets.
 
@@ -161,10 +161,9 @@ bin/                     # CLI entry point
 src/                     # Server source code
 client/                  # Web Audio client (Vite build)
 agents/
-  claude/hooks/          # Claude Code hook scripts
-  cursor/                # Cursor hooks + installer
   opencode/plugins/      # OpenCode plugin
   pi/extensions/         # Pi extension
+src/install-hooks.ts     # Claude/Cursor install logic + hook config writers
 ```
 
 ## Future Work

--- a/client/src/audio-engine.ts
+++ b/client/src/audio-engine.ts
@@ -205,12 +205,17 @@ export class AudioEngine {
     // Get sound config based on event type
     let config: SoundParams
 
-    if (event_type === 'PreToolUse' || event_type === 'PostToolUse') {
+    const isToolEvent =
+      event_type === 'PreToolUse' ||
+      event_type === 'PostToolUse' ||
+      event_type === 'PostToolUseFailure'
+
+    if (isToolEvent) {
       // Use tool-specific sound
       const tools = SOUND_CONFIG.tools as Record<string, SoundParams>
       config = tools[tool_name] || tools.default
 
-      // Make PostToolUse slightly different (higher pitch)
+      // Make PostToolUse slightly brighter (higher pitch)
       if (event_type === 'PostToolUse' && config.note) {
         const noteKeys = Object.keys(NOTE_FREQ)
         const noteIndex = noteKeys.indexOf(config.note)
@@ -219,6 +224,16 @@ export class AudioEngine {
             ...config,
             note: noteKeys[noteIndex + 1],
           }
+        }
+      }
+
+      // Tool failures get a darker, sharper timbre.
+      if (event_type === 'PostToolUseFailure') {
+        config = {
+          ...config,
+          type: 'square',
+          gain: Math.min(0.45, (config.gain || 0.2) + 0.08),
+          duration: Math.max(config.duration, 0.16),
         }
       }
     } else {

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -15,11 +15,35 @@ export const SOUND_CONFIG: Record<string, SoundParams | Record<string, SoundPara
     type: 'sine',
     gain: 0.3,
   },
+  UserPromptSubmit: {
+    note: 'B3',
+    duration: 0.18,
+    type: 'triangle',
+    gain: 0.2,
+  },
   Stop: {
     notes: ['C5', 'E5', 'G5'],
     duration: 0.6,
     type: 'sine',
     gain: 0.5,
+  },
+  PermissionRequest: {
+    note: 'A5',
+    duration: 0.35,
+    type: 'square',
+    gain: 0.42,
+  },
+  Notification: {
+    note: 'E5',
+    duration: 0.2,
+    type: 'triangle',
+    gain: 0.22,
+  },
+  SubagentStart: {
+    note: 'G4',
+    duration: 0.26,
+    type: 'sine',
+    gain: 0.3,
   },
   SubagentStop: {
     note: 'E5',
@@ -27,11 +51,65 @@ export const SOUND_CONFIG: Record<string, SoundParams | Record<string, SoundPara
     type: 'triangle',
     gain: 0.35,
   },
+  TeammateIdle: {
+    note: 'E3',
+    duration: 0.28,
+    type: 'sine',
+    gain: 0.15,
+  },
+  TaskCompleted: {
+    notes: ['G4', 'B4', 'D5'],
+    duration: 0.38,
+    type: 'sine',
+    gain: 0.32,
+  },
+  InstructionsLoaded: {
+    note: 'D5',
+    duration: 0.18,
+    type: 'triangle',
+    gain: 0.2,
+  },
+  ConfigChange: {
+    note: 'F4',
+    duration: 0.2,
+    type: 'sawtooth',
+    gain: 0.2,
+  },
+  WorktreeCreate: {
+    note: 'A4',
+    duration: 0.22,
+    type: 'triangle',
+    gain: 0.22,
+  },
+  WorktreeRemove: {
+    note: 'D3',
+    duration: 0.24,
+    type: 'triangle',
+    gain: 0.2,
+  },
   PreCompact: {
     note: 'D4',
     duration: 0.2,
     type: 'sawtooth',
     gain: 0.15,
+  },
+  PostCompact: {
+    note: 'C4',
+    duration: 0.22,
+    type: 'triangle',
+    gain: 0.17,
+  },
+  Elicitation: {
+    note: 'F5',
+    duration: 0.26,
+    type: 'square',
+    gain: 0.3,
+  },
+  ElicitationResult: {
+    note: 'A4',
+    duration: 0.24,
+    type: 'triangle',
+    gain: 0.24,
   },
 
   // Tool-specific sounds (for PreToolUse/PostToolUse)

--- a/client/src/visualizer.ts
+++ b/client/src/visualizer.ts
@@ -462,12 +462,26 @@ export class Visualizer {
       lifetime = 56
       lineWidth = 3
       pulseCount = 2
-    } else if (event_type === 'PreToolUse' || event_type === 'PostToolUse') {
-      baseRadius = tool_name === 'Task' ? 12 : 8
-      growthRate = tool_name === 'Task' ? 2.2 : 1.7
-      maxPulseRadius = tool_name === 'Task' ? 88 : 52
-      lifetime = tool_name === 'Task' ? 44 : 30
-      lineWidth = tool_name === 'Task' ? 2.6 : 1.8
+    } else if (event_type === 'PermissionRequest' || event_type === 'Elicitation') {
+      baseRadius = 12
+      growthRate = 2.1
+      maxPulseRadius = 96
+      lifetime = 48
+      lineWidth = 2.8
+      pulseCount = 2
+    } else if (
+      event_type === 'PreToolUse' ||
+      event_type === 'PostToolUse' ||
+      event_type === 'PostToolUseFailure'
+    ) {
+      const isTask = tool_name === 'Task'
+      const isFailure = event_type === 'PostToolUseFailure'
+      baseRadius = isTask ? 12 : isFailure ? 10 : 8
+      growthRate = isTask ? 2.2 : isFailure ? 1.9 : 1.7
+      maxPulseRadius = isTask ? 88 : isFailure ? 68 : 52
+      lifetime = isTask ? 44 : isFailure ? 36 : 30
+      lineWidth = isTask ? 2.6 : isFailure ? 2.2 : 1.8
+      pulseCount = isFailure ? 2 : 1
     }
 
     for (let i = 0; i < pulseCount; i++) {

--- a/src/emit.ts
+++ b/src/emit.ts
@@ -1,22 +1,23 @@
 /**
  * bingbong emit
  *
- * Reads hook payload JSON from stdin, spreads it into the POST body
- * with event_type/timestamp/machine_id overlaid, and sends it to
- * the bingbong server's /events endpoint.
+ * Reads hook payload JSON from stdin, normalizes event names where needed,
+ * overlays required fields, and sends the event to /events.
  *
  * Always exits 0. Completely silent (no stdout, no stderr).
  */
 
 import os from "node:os";
+import { inferDefaultToolName, normalizeEventType, toRecord, toString } from "./events";
 
 export async function emit(argv: string[]): Promise<void> {
   const enabled = (process.env.BINGBONG_ENABLED || "true").toLowerCase() !== "false";
   if (!enabled) return;
 
-  const eventType = argv[0];
-  if (!eventType) return;
+  const rawEventType = argv[0];
+  if (!rawEventType) return;
 
+  const { eventType, originalEventType } = normalizeEventType(rawEventType);
   const url = process.env.BINGBONG_URL || "http://localhost:3334";
 
   // Read stdin: if TTY (interactive terminal), skip — no data to read.
@@ -43,22 +44,42 @@ export async function emit(argv: string[]): Promise<void> {
           t.unref();
         }),
       ]);
-      if (raw.trim()) input = JSON.parse(raw);
+
+      if (raw.trim()) {
+        input = toRecord(JSON.parse(raw));
+      }
     } catch {
       // Malformed JSON — proceed with empty input
     }
   }
 
-  // Normalize session_id — agents use different field names
-  const sessionId = (input.session_id ?? input.conversation_id ?? input.generation_id ?? "unknown") as string;
+  const sessionId = toString(
+    input.session_id ?? input.conversation_id ?? input.generation_id,
+    "unknown",
+  );
 
-  // Spread stdin payload, overlay our fields
+  const toolInput = toRecord(input.tool_input ?? input.toolInput);
+  const toolOutput = toRecord(input.tool_output ?? input.toolOutput);
+
+  if (originalEventType && toolOutput.original_event_type === undefined) {
+    toolOutput.original_event_type = originalEventType;
+  }
+
+  const toolName = toString(
+    input.tool_name ?? input.toolName,
+    inferDefaultToolName(originalEventType || rawEventType),
+  );
+
   const payload = {
     ...input,
     event_type: eventType,
     session_id: sessionId,
     machine_id: process.env.BINGBONG_MACHINE_ID || os.hostname(),
     timestamp: new Date().toISOString(),
+    cwd: toString(input.cwd ?? input.directory, ""),
+    tool_name: toolName,
+    tool_input: toolInput,
+    tool_output: toolOutput,
   };
 
   try {

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,126 @@
+export interface ClaudeHookEventSpec {
+  event: string;
+  matcherSupported: boolean;
+}
+
+export interface ClaudeInstallEvent {
+  event: string;
+  matcher?: string;
+}
+
+export const CLAUDE_HOOK_EVENT_SPECS: ClaudeHookEventSpec[] = [
+  { event: "SessionStart", matcherSupported: true },
+  { event: "UserPromptSubmit", matcherSupported: false },
+  { event: "PreToolUse", matcherSupported: true },
+  { event: "PermissionRequest", matcherSupported: true },
+  { event: "PostToolUse", matcherSupported: true },
+  { event: "PostToolUseFailure", matcherSupported: true },
+  { event: "Notification", matcherSupported: true },
+  { event: "SubagentStart", matcherSupported: true },
+  { event: "SubagentStop", matcherSupported: true },
+  { event: "Stop", matcherSupported: false },
+  { event: "TeammateIdle", matcherSupported: false },
+  { event: "TaskCompleted", matcherSupported: false },
+  { event: "InstructionsLoaded", matcherSupported: false },
+  { event: "ConfigChange", matcherSupported: true },
+  { event: "WorktreeCreate", matcherSupported: false },
+  { event: "WorktreeRemove", matcherSupported: false },
+  { event: "PreCompact", matcherSupported: true },
+  { event: "PostCompact", matcherSupported: true },
+  { event: "Elicitation", matcherSupported: true },
+  { event: "ElicitationResult", matcherSupported: true },
+  { event: "SessionEnd", matcherSupported: true },
+];
+
+const MATCH_ALL = ".*";
+
+export const CLAUDE_HOOK_INSTALL_EVENTS: ClaudeInstallEvent[] = CLAUDE_HOOK_EVENT_SPECS.map(
+  ({ event, matcherSupported }) =>
+    matcherSupported ? { event, matcher: MATCH_ALL } : { event },
+);
+
+const EVENT_TYPE_ALIASES: Record<string, string> = {
+  // Cursor hook names
+  beforeShellExecution: "PreToolUse",
+  afterShellExecution: "PostToolUse",
+  beforeMCPExecution: "PreToolUse",
+  afterMCPExecution: "PostToolUse",
+  beforeReadFile: "PreToolUse",
+  afterFileEdit: "PostToolUse",
+  beforeSubmitPrompt: "UserPromptSubmit",
+  afterAgentResponse: "Notification",
+  afterAgentThought: "Notification",
+  stop: "Stop",
+
+  // OpenCode (fallback normalization)
+  "tool.execute.before": "PreToolUse",
+  "tool.execute.after": "PostToolUse",
+  "session.created": "SessionStart",
+  "session.deleted": "SessionEnd",
+  "session.idle": "Stop",
+  "session.error": "Stop",
+
+  // Pi (fallback normalization)
+  tool_call: "PreToolUse",
+  tool_result: "PostToolUse",
+  session_start: "SessionStart",
+  session_before_compact: "PreCompact",
+  session_compact: "PostCompact",
+  session_shutdown: "SessionEnd",
+  agent_end: "Stop",
+};
+
+const DEFAULT_TOOL_NAME_BY_EVENT: Record<string, string> = {
+  beforeShellExecution: "Bash",
+  afterShellExecution: "Bash",
+  beforeMCPExecution: "MCP",
+  afterMCPExecution: "MCP",
+  beforeReadFile: "Read",
+  afterFileEdit: "Edit",
+  "tool.execute.before": "tool",
+  "tool.execute.after": "tool",
+};
+
+export function normalizeEventType(rawEventType: string): {
+  eventType: string;
+  originalEventType?: string;
+} {
+  const trimmed = rawEventType.trim();
+  if (!trimmed) {
+    return { eventType: "UnknownEvent" };
+  }
+
+  const mapped = EVENT_TYPE_ALIASES[trimmed] || trimmed;
+  if (mapped === trimmed) {
+    return { eventType: mapped };
+  }
+
+  return {
+    eventType: mapped,
+    originalEventType: trimmed,
+  };
+}
+
+export function inferDefaultToolName(rawEventType: string): string {
+  return DEFAULT_TOOL_NAME_BY_EVENT[rawEventType] || "";
+}
+
+export function toRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return { ...(value as Record<string, unknown>) };
+  }
+
+  if (value === undefined || value === null) {
+    return {};
+  }
+
+  return { value };
+}
+
+export function toString(value: unknown, fallback: string): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  return fallback;
+}

--- a/src/install-hooks.ts
+++ b/src/install-hooks.ts
@@ -9,6 +9,7 @@ import { existsSync, mkdirSync, renameSync, unlinkSync, chmodSync, statSync } fr
 import { readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve, dirname } from "node:path";
+import { CLAUDE_HOOK_INSTALL_EVENTS } from "./events";
 
 const ROOT_DIR = resolve(import.meta.dir, "..");
 const AGENTS_DIR = join(ROOT_DIR, "agents");
@@ -184,20 +185,6 @@ async function atomicWriteJson(filePath: string, data: object) {
 // Claude Code installer
 // ---------------------------------------------------------------------------
 
-const CLAUDE_EVENTS: Array<{ event: string; matcher: string }> = [
-  { event: "PreToolUse",        matcher: ".*" },
-  { event: "PostToolUse",       matcher: ".*" },
-  { event: "SessionStart",      matcher: "" },
-  { event: "SessionEnd",        matcher: "" },
-  { event: "Stop",              matcher: "" },
-  { event: "SubagentStop",      matcher: "" },
-  { event: "PermissionRequest", matcher: "" },
-  { event: "Notification",      matcher: "" },
-  { event: "PreCompact",        matcher: "" },
-  { event: "Setup",             matcher: "" },
-  { event: "UserPromptSubmit",  matcher: "" },
-];
-
 function isBingbongClaudeEntry(entry: any): boolean {
   const hooks = entry?.hooks;
   if (!Array.isArray(hooks)) return false;
@@ -218,15 +205,22 @@ async function installClaude(_agentsDir: string, dryRun: boolean): Promise<strin
   const cleanedHooks: Record<string, any[]> = {};
   for (const [event, entries] of Object.entries(existingHooks)) {
     if (!Array.isArray(entries)) continue;
-    cleanedHooks[event] = entries.filter((entry: any) => !isBingbongClaudeEntry(entry));
+
+    const filtered = entries.filter((entry: any) => !isBingbongClaudeEntry(entry));
+    if (filtered.length > 0) {
+      cleanedHooks[event] = filtered;
+    }
   }
 
   // Add fresh bingbong entries using `bingbong emit`
-  for (const { event, matcher } of CLAUDE_EVENTS) {
-    const bingbongEntry = {
-      matcher,
+  for (const { event, matcher } of CLAUDE_HOOK_INSTALL_EVENTS) {
+    const bingbongEntry: { matcher?: string; hooks: Array<{ type: "command"; command: string }> } = {
       hooks: [{ type: "command", command: `${bingbongCmd} emit ${event}` }],
     };
+
+    if (matcher) {
+      bingbongEntry.matcher = matcher;
+    }
 
     if (!cleanedHooks[event]) {
       cleanedHooks[event] = [];

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@
  */
 
 import clientIndex from "../client/index.html";
+import { inferDefaultToolName, normalizeEventType, toRecord, toString } from "./events";
 
 const VERSION = "0.1.5";
 const MAX_EVENT_LOG_LINES = 1000;
@@ -376,6 +377,35 @@ const SESSION_COLORS = [
 // WebSocket clients
 const wsClients = new Set<WebSocket>();
 
+function normalizeIncomingEvent(raw: unknown): BingbongEvent {
+  const input = toRecord(raw);
+  const rawEventType = toString(input.event_type ?? input.hook_event_name, "UnknownEvent");
+  const { eventType, originalEventType } = normalizeEventType(rawEventType);
+
+  const toolOutput = toRecord(input.tool_output ?? input.toolOutput);
+  if (originalEventType && toolOutput.original_event_type === undefined) {
+    toolOutput.original_event_type = originalEventType;
+  }
+
+  return {
+    ...input,
+    event_type: eventType,
+    session_id: toString(
+      input.session_id ?? input.conversation_id ?? input.generation_id,
+      "unknown",
+    ),
+    machine_id: toString(input.machine_id, "unknown-machine"),
+    timestamp: toString(input.timestamp, new Date().toISOString()),
+    cwd: toString(input.cwd ?? input.directory, ""),
+    tool_name: toString(
+      input.tool_name ?? input.toolName,
+      inferDefaultToolName(originalEventType || rawEventType),
+    ),
+    tool_input: toRecord(input.tool_input ?? input.toolInput),
+    tool_output: toolOutput,
+  } as BingbongEvent;
+}
+
 function getOrCreateSession(event: BingbongEvent): Session {
   const key = `${event.machine_id}:${event.session_id}`;
 
@@ -483,11 +513,17 @@ export async function startServer(port: number): Promise<StartServerResult> {
       // HTTP POST for events from hooks
       if (req.method === "POST" && url.pathname === "/events") {
         try {
-          const event = (await req.json()) as BingbongEvent;
+          const event = normalizeIncomingEvent(await req.json());
           const enriched = enrichEvent(event);
 
+          const originalEventType = toString(enriched.tool_output.original_event_type, "");
+          const eventLabel =
+            originalEventType && originalEventType !== enriched.event_type
+              ? `${enriched.event_type} (from ${originalEventType})`
+              : enriched.event_type;
+
           logInfo(
-            `[Event] ${enriched.event_type} | session=${enriched.session_id.slice(0, 8)} | tool=${enriched.tool_name || "n/a"}`,
+            `[Event] ${eventLabel} | session=${enriched.session_id.slice(0, 8)} | tool=${enriched.tool_name || "n/a"}`,
           );
 
           broadcast(enriched);


### PR DESCRIPTION
## Summary
This PR extends the earlier docs-only work and implements the full scope for issue #13.

### What landed
- Added `src/events.ts` as the single code source for:
  - Full current official Claude hook event list
  - Matcher support metadata
  - Cross-harness alias normalization
- Updated `install-hooks claude` to install the full official Claude event set.
  - Removed stale `Setup` event
  - Writes `matcher: ".*"` only for matcher-capable events
  - Omits matcher for events where Claude ignores matchers
- Hardened event ingest path end-to-end:
  - `emit` now normalizes known harness-native names to Claude baseline names
  - `server` now defensively normalizes `/events` payloads and defaults missing fields
  - Original source event names are preserved in `tool_output.original_event_type` when mapped
  - Logging now shows mapped-origin context (`EventType (from OriginalType)`)
- Extended client handling for new baseline events:
  - Added dedicated sound mappings for Claude lifecycle events
  - Added explicit failure handling for `PostToolUseFailure`
  - Added stronger visual pulse treatment for `PermissionRequest` / `Elicitation` and tool failures
- Docs updates:
  - `EVENTS.md` is now the maintained source-of-truth matrix
  - README keeps concise Claude-baseline wording and links to `EVENTS.md`

## Validation
- `bun run build:client`
- `bun run bin/cli.ts test` (against a live local server on an ephemeral port)
- `bun run bin/cli.ts install-hooks --dry-run claude` (with temp HOME)
- Manual mapping smoke: emitted `beforeShellExecution` and verified normalized server log output

## Risks / follow-ups
- Cursor/OpenCode/Pi parity is still partial for events that have no true 1:1 equivalents; this is documented in `EVENTS.md`.
- `/events` normalization is permissive by design (best-effort defaults instead of strict rejection). If we want strict mode later, add explicit schema validation + optional reject behavior.

Closes #13