### PR TITLE
Fix install-hooks in bundled binaries

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -8,7 +8,7 @@
 
 import { startServer, type RuntimeLogger } from "../src/server";
 
-const VERSION = "0.1.5";
+const VERSION = "0.1.7";
 
 let activeLogger: RuntimeLogger | null = null;
 

--- a/docs/solutions/integration-issues/bun-standalone-binary-install-hooks-bunfs-agents.md
+++ b/docs/solutions/integration-issues/bun-standalone-binary-install-hooks-bunfs-agents.md
@@ -1,0 +1,131 @@
+---
+title: "Standalone Bun Binary Broke `install-hooks` with `/$bunfs/agents`"
+category: integration-issues
+problem_type: integration_issue
+component: tooling
+root_cause: config_error
+resolution_type: code_fix
+severity: high
+tags:
+  - bun
+  - standalone-binary
+  - install-hooks
+  - curl-installer
+  - claude-code
+  - bunfs
+  - release
+  - hooks
+module: distribution
+symptoms:
+  - "`bingbong install-hooks --dry-run claude` failed in compiled binaries with `Error: Could not find agents directory at /$bunfs/agents`"
+  - "Fresh-machine installs via the curl installer could not complete hook setup"
+  - "The failure happened before the Claude and Cursor installers ran"
+date: 2026-03-27
+---
+
+# Standalone Bun Binary Broke `install-hooks` with `/$bunfs/agents`
+
+## Problem
+After installing the standalone Bingbong binary via the curl installer on a fresh machine, `bingbong install-hooks claude` failed immediately with:
+
+```text
+Error: Could not find agents directory at /$bunfs/agents
+This can happen with bundled builds. Install from source checkout or binary release package.
+```
+
+The bug only appeared in compiled/install flows. Source checkouts still worked because the repo actually had an `agents/` directory on disk.
+
+## Investigation
+
+1. **Reproduced the failure with a compiled binary**
+
+```bash
+bun build ./bin/cli.ts --compile --outfile /tmp/bingbong-build/bingbong
+HOME=/tmp/bingbong-home PATH=/tmp/bingbong-build:$PATH \
+  /tmp/bingbong-build/bingbong install-hooks --dry-run claude
+```
+
+2. **Traced the failure to early runtime path resolution**
+   `src/install-hooks.ts` derived `ROOT_DIR` from `import.meta.dir`, then built `AGENTS_DIR`, then blocked all installers on `existsSync(AGENTS_DIR)`.
+
+3. **Confirmed the check was stale for Claude and Cursor**
+   `installClaude()` and `installCursor()` no longer read files from `agents/`. They only write `bingbong emit <Event>` commands into agent config.
+
+4. **Checked release/install packaging**
+   The curl installer ships only the compiled binary. Existing release smoke tests validated binary install and embedded UI assets, but did not exercise `install-hooks`.
+
+5. **Rejected a packaging-only fix**
+   A Bun/package config change to try to ship `agents/` would not solve the stale Claude/Cursor preflight check, and it would still leave OpenCode/Pi dependent on runtime filesystem layout.
+
+## Root Cause
+`install-hooks` still assumed it was running from a source checkout with a real `agents/` directory on disk. In a Bun standalone binary, `import.meta.dir` resolves under Bun's virtual filesystem (`/$bunfs/...`), so `AGENTS_DIR` became `/$bunfs/agents`.
+
+That caused two separate problems:
+
+- Claude and Cursor were blocked by a global filesystem check they no longer needed.
+- OpenCode and Pi still read plugin/extension payloads from runtime disk paths instead of from the bundle.
+
+## Working Solution
+
+### 1) Remove the global runtime `agents/` preflight
+`src/install-hooks.ts`
+
+```ts
+const INSTALLERS: Record<string, (dryRun: boolean) => Promise<string>> = {
+  claude: installClaude,
+  cursor: installCursor,
+  opencode: installOpencode,
+  pi: installPi,
+};
+
+const configPath = await installer(dryRun);
+```
+
+This stops `install-hooks` from failing before it reaches the actual agent-specific installer.
+
+### 2) Embed OpenCode and Pi assets at build time
+`src/install-hooks.ts`
+
+```ts
+import opencodePluginSource from "../agents/opencode/plugins/bingbong.js" with { type: "text" };
+import piExtensionSource from "../agents/pi/extensions/bingbong.ts" with { type: "text" };
+```
+
+`installOpencode()` now writes `opencodePluginSource` directly, and `installPi()` transforms `piExtensionSource` in memory before writing it out. That makes both installers safe in standalone binaries.
+
+### 3) Add release-path regression coverage
+`scripts/test-local-release.sh`
+
+- Install the prebuilt binary through the local release harness
+- Run `install-hooks --dry-run` for `claude`, `cursor`, `opencode`, and `pi`
+- Keep the existing UI asset smoke checks
+
+## Verification That Fixed It
+
+- Reproduced the original `/$bunfs/agents` failure with a compiled standalone binary before the patch.
+- Rebuilt the binary and confirmed `install-hooks --dry-run` succeeds for `claude`, `cursor`, `opencode`, and `pi`.
+- Ran `scripts/test-local-release.sh` end to end and confirmed:
+  - prebuilt installer path was used
+  - checksum verification ran
+  - `install-hooks` worked from the standalone binary
+  - embedded UI assets still served correctly
+
+## Prevention Checklist
+
+- Treat `bun build --compile` as a different runtime, not just a packaging step.
+- Do not gate one installer on filesystem assets needed only by other installers.
+- For assets that must ship with the standalone binary, embed them at build time or install them explicitly alongside the binary.
+- Require `scripts/test-local-release.sh` for release/distribution changes.
+- Treat any `/$bunfs` path leakage in user-facing errors as release-blocking.
+
+## Related References
+
+- PR: #30
+- Commit: `5dac071` — fix `install-hooks` in bundled binaries
+- Related docs:
+  - `docs/solutions/integration-issues/portable-hook-configs-emit-subcommand.md`
+  - `docs/solutions/integration-issues/bun-standalone-binary-js-chunk-404-base-href.md`
+- Release context:
+  - `docs/guides/releasing-binaries.md`
+  - `docs/brainstorms/2026-02-24-binary-installer-without-npm-brainstorm.md`
+  - `docs/plans/2026-02-24-feat-binary-release-installer-without-npm-plan.md`

--- a/docs/solutions/integration-issues/bun-standalone-binary-install-hooks-bunfs-agents.md
+++ b/docs/solutions/integration-issues/bun-standalone-binary-install-hooks-bunfs-agents.md
@@ -3,7 +3,7 @@ title: "Standalone Bun Binary Broke `install-hooks` with `/$bunfs/agents`"
 category: integration-issues
 problem_type: integration_issue
 component: tooling
-root_cause: config_error
+root_cause: wrong_api
 resolution_type: code_fix
 severity: high
 tags:
@@ -20,6 +20,7 @@ symptoms:
   - "`bingbong install-hooks --dry-run claude` failed in compiled binaries with `Error: Could not find agents directory at /$bunfs/agents`"
   - "Fresh-machine installs via the curl installer could not complete hook setup"
   - "The failure happened before the Claude and Cursor installers ran"
+  - "Standalone binaries could not load OpenCode or Pi assets from a repo-local `agents/` directory"
 date: 2026-03-27
 ---
 
@@ -33,7 +34,7 @@ Error: Could not find agents directory at /$bunfs/agents
 This can happen with bundled builds. Install from source checkout or binary release package.
 ```
 
-The bug only appeared in compiled/install flows. Source checkouts still worked because the repo actually had an `agents/` directory on disk.
+That message was misleading for the actual distribution model. The standalone release binary was supposed to support `bingbong install-hooks <agent>` directly, but `install-hooks` still assumed it was running from a source checkout with a real `agents/` directory on disk.
 
 ## Investigation
 
@@ -58,7 +59,7 @@ HOME=/tmp/bingbong-home PATH=/tmp/bingbong-build:$PATH \
    A Bun/package config change to try to ship `agents/` would not solve the stale Claude/Cursor preflight check, and it would still leave OpenCode/Pi dependent on runtime filesystem layout.
 
 ## Root Cause
-`install-hooks` still assumed it was running from a source checkout with a real `agents/` directory on disk. In a Bun standalone binary, `import.meta.dir` resolves under Bun's virtual filesystem (`/$bunfs/...`), so `AGENTS_DIR` became `/$bunfs/agents`.
+`install-hooks` used the wrong runtime boundary for a compiled Bun executable. In source runs, `import.meta.dir` points at the real repo and `agents/` exists beside the code. In `bun build --compile` output, `import.meta.dir` resolves under Bun's virtual filesystem (`/$bunfs/...`), so `AGENTS_DIR` became `/$bunfs/agents`.
 
 That caused two separate problems:
 
@@ -100,6 +101,11 @@ import piExtensionSource from "../agents/pi/extensions/bingbong.ts" with { type:
 - Run `install-hooks --dry-run` for `claude`, `cursor`, `opencode`, and `pi`
 - Keep the existing UI asset smoke checks
 
+## Why This Works
+The root problem was not missing files in the repo. It was assuming a compiled Bun binary could still discover install-time assets through `import.meta.dir` like a source checkout.
+
+By importing the OpenCode and Pi assets as raw text, the binary carries the payloads it needs. By removing the unconditional `agents/` directory check, Claude and Cursor no longer fail on a filesystem path they do not use. The result is that all four `install-hooks` flows work from the shipped standalone binary instead of only from a source checkout.
+
 ## Verification That Fixed It
 
 - Reproduced the original `/$bunfs/agents` failure with a compiled standalone binary before the patch.
@@ -115,6 +121,7 @@ import piExtensionSource from "../agents/pi/extensions/bingbong.ts" with { type:
 - Treat `bun build --compile` as a different runtime, not just a packaging step.
 - Do not gate one installer on filesystem assets needed only by other installers.
 - For assets that must ship with the standalone binary, embed them at build time or install them explicitly alongside the binary.
+- Do not use `import.meta.dir` as a proxy for an installed resource directory in Bun standalone builds.
 - Require `scripts/test-local-release.sh` for release/distribution changes.
 - Treat any `/$bunfs` path leakage in user-facing errors as release-blocking.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bingbong",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Soundscapes for coding agents - audio monitoring for Claude Code, Cursor, and other AI coding assistants",
   "type": "module",
   "bin": {

--- a/scripts/test-local-release.sh
+++ b/scripts/test-local-release.sh
@@ -165,6 +165,19 @@ fi
 echo "[test-local-release] smoke test: bingbong --help"
 "$INSTALL_DIR/bingbong" --help >/dev/null
 
+echo "[test-local-release] smoke test: install-hooks in standalone binary"
+TEST_HOME="$WORKDIR/test-home"
+mkdir -p "$TEST_HOME"
+
+for agent in claude cursor opencode pi; do
+  log_path="$WORKDIR/install-hooks-$agent.log"
+  if ! HOME="$TEST_HOME" PATH="$INSTALL_DIR:$PATH" "$INSTALL_DIR/bingbong" install-hooks --dry-run "$agent" >"$log_path" 2>&1; then
+    echo "[test-local-release] FAIL: install-hooks --dry-run $agent failed" >&2
+    sed -n '1,120p' "$log_path" >&2 || true
+    exit 1
+  fi
+done
+
 echo "[test-local-release] smoke test: serve UI on :$APP_PORT"
 "$INSTALL_DIR/bingbong" --port "$APP_PORT" >"$APP_LOG" 2>&1 &
 APP_PID=$!
@@ -198,5 +211,6 @@ fi
 echo "[test-local-release] PASS"
 echo "  - installer used prebuilt artifacts"
 echo "  - checksum verification path executed"
+echo "  - install-hooks works from the standalone binary"
 echo "  - installed binary served embedded UI assets"
 echo "  - install log: $INSTALL_LOG"

--- a/src/install-hooks.ts
+++ b/src/install-hooks.ts
@@ -8,10 +8,10 @@
 import { existsSync, mkdirSync, renameSync, unlinkSync, chmodSync, statSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join, resolve, dirname } from "node:path";
+import { join, dirname } from "node:path";
 
-const ROOT_DIR = resolve(import.meta.dir, "..");
-const AGENTS_DIR = join(ROOT_DIR, "agents");
+import opencodePluginSource from "../agents/opencode/plugins/bingbong.js" with { type: "text" };
+import piExtensionSource from "../agents/pi/extensions/bingbong.ts" with { type: "text" };
 
 function getBingbongCommand(): string {
   try {
@@ -37,7 +37,7 @@ const AGENTS: Record<string, { display: string; configHint: string }> = {
   pi:       { display: "Pi",          configHint: "~/.pi/agent/extensions/" },
 };
 
-const INSTALLERS: Record<string, (agentsDir: string, dryRun: boolean) => Promise<string>> = {
+const INSTALLERS: Record<string, (dryRun: boolean) => Promise<string>> = {
   claude: installClaude,
   cursor: installCursor,
   opencode: installOpencode,
@@ -86,15 +86,7 @@ export async function installHooks(argv: string[]) {
     process.exit(1);
   }
 
-  if (!existsSync(AGENTS_DIR)) {
-    console.error(
-      `Error: Could not find agents directory at ${AGENTS_DIR}\n` +
-      `This can happen with bundled builds. Install from source checkout or binary release package.`
-    );
-    process.exit(1);
-  }
-
-  const configPath = await installer(AGENTS_DIR, dryRun);
+  const configPath = await installer(dryRun);
   if (dryRun) {
     console.log(`\nRun without --dry-run to apply these changes.`);
   } else {
@@ -207,7 +199,7 @@ function isBingbongClaudeEntry(entry: any): boolean {
   });
 }
 
-async function installClaude(_agentsDir: string, dryRun: boolean): Promise<string> {
+async function installClaude(dryRun: boolean): Promise<string> {
   const bingbongCmd = getBingbongCommand();
   const configPath = join(homedir(), ".claude", "settings.json");
 
@@ -269,7 +261,7 @@ function isBingbongCursorEntry(entry: any): boolean {
   return cmd.includes("bingbong-hook.sh") || cmd.includes("bingbong emit");
 }
 
-async function installCursor(_agentsDir: string, dryRun: boolean): Promise<string> {
+async function installCursor(dryRun: boolean): Promise<string> {
   const bingbongCmd = getBingbongCommand();
   const configPath = join(homedir(), ".cursor", "hooks.json");
 
@@ -306,25 +298,17 @@ async function installCursor(_agentsDir: string, dryRun: boolean): Promise<strin
 // OpenCode installer
 // ---------------------------------------------------------------------------
 
-async function installOpencode(agentsDir: string, dryRun: boolean): Promise<string> {
-  const sourcePath = join(agentsDir, "opencode", "plugins", "bingbong.js");
+async function installOpencode(dryRun: boolean): Promise<string> {
   const targetPath = join(homedir(), ".config", "opencode", "plugins", "bingbong.js");
-
-  if (!existsSync(sourcePath)) {
-    console.error(`Error: Source plugin not found: ${sourcePath}`);
-    process.exit(1);
-  }
-
-  const content = await readFile(sourcePath, "utf-8");
 
   if (dryRun) {
     const existingContent = existsSync(targetPath) ? await readFile(targetPath, "utf-8") : null;
-    printPreview(targetPath, existingContent, content);
+    printPreview(targetPath, existingContent, opencodePluginSource);
     return targetPath;
   }
 
   ensureDir(dirname(targetPath));
-  await writeFile(targetPath, content, "utf-8");
+  await writeFile(targetPath, opencodePluginSource, "utf-8");
 
   return targetPath;
 }
@@ -333,19 +317,11 @@ async function installOpencode(agentsDir: string, dryRun: boolean): Promise<stri
 // Pi installer
 // ---------------------------------------------------------------------------
 
-async function installPi(agentsDir: string, dryRun: boolean): Promise<string> {
-  const sourcePath = join(agentsDir, "pi", "extensions", "bingbong.ts");
+async function installPi(dryRun: boolean): Promise<string> {
   const extensionsDir = process.env.PI_EXTENSIONS_DIR || join(homedir(), ".pi", "agent", "extensions");
   const targetPath = join(extensionsDir, "bingbong.ts");
   const bingbongUrl = process.env.BINGBONG_URL || "http://localhost:3334";
-
-  if (!existsSync(sourcePath)) {
-    console.error(`Error: Source extension not found: ${sourcePath}`);
-    process.exit(1);
-  }
-
-  const content = await readFile(sourcePath, "utf-8");
-  const transformed = content.replace("__BINGBONG_URL__", bingbongUrl);
+  const transformed = piExtensionSource.replace("__BINGBONG_URL__", bingbongUrl);
 
   if (dryRun) {
     const existingContent = existsSync(targetPath) ? await readFile(targetPath, "utf-8") : null;

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@
 
 import clientIndex from "../client/index.html";
 
-const VERSION = "0.1.5";
+const VERSION = "0.1.7";
 const MAX_EVENT_LOG_LINES = 1000;
 
 interface RuntimeLogger {


### PR DESCRIPTION
## Problem
Standalone `bun --compile` builds resolve `import.meta.dir` under `/$bunfs`, so `bingbong install-hooks` tried to read `/$bunfs/agents` and failed before the Claude installer could run.

## Fix
- embed the OpenCode and Pi hook assets as raw text imports at build time
- remove the runtime `agents/` directory dependency from `install-hooks`
- extend the local release smoke test to run `install-hooks --dry-run` for all supported agents against the installed binary

## Verification
- reproduced the original failure with a compiled binary
- `scripts/test-local-release.sh` passes end to end