### PR TITLE
migrate client to new design system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs
 *.local.md
 test-results/
 todos/
+.prose/

--- a/client/index.html
+++ b/client/index.html
@@ -5,6 +5,18 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <base href="/" />
         <title>Bingbong</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+        <script>
+            // Set theme from system preference before first paint
+            const themeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+            const applyTheme = () => {
+                document.documentElement.dataset.theme = themeQuery.matches ? "dark" : "light";
+            };
+            applyTheme();
+            themeQuery.addEventListener("change", applyTheme);
+        </script>
     </head>
     <body>
         <div class="audio-banner" id="audio-banner" role="button" tabindex="0" aria-label="Click to enable audio" hidden>

--- a/client/src/styles/design-system.css
+++ b/client/src/styles/design-system.css
@@ -1,0 +1,571 @@
+/* ============================================
+   Bingbong Design System
+   Based on Component Library A variations
+   ============================================ */
+
+/* ============================================
+   Theme: Light (Cream) - Default
+   Font pairing: Geist Mono (interface) + Inter (display)
+   ============================================ */
+:root,
+[data-theme="light"] {
+    /* Colors - Core Palette */
+    --color-teal: #0D5E5E;
+    --color-marigold: #E8A832;
+    --color-rose: #E88FA0;
+    --color-cream: #FAF3E3;
+    --color-sand: #F5ECD7;
+
+    /* Colors - Semantic */
+    --color-bg-base: var(--color-cream);
+    --color-bg-surface: #FFFFFF;
+    --color-bg-elevated: var(--color-sand);
+    --color-bg-accent: var(--color-teal);
+    --color-bg-accent-secondary: var(--color-marigold);
+
+    /* Colors - Border */
+    --color-border: var(--color-teal);
+    --color-border-subtle: rgba(13, 94, 94, 0.2);
+
+    /* Colors - Text */
+    --color-text-primary: var(--color-teal);
+    --color-text-secondary: rgba(13, 94, 94, 0.7);
+    --color-text-muted: rgba(13, 94, 94, 0.5);
+    --color-text-inverse: var(--color-cream);
+    --color-text-on-accent: var(--color-cream);
+    --color-text-on-marigold: var(--color-teal);
+
+    /* Colors - State */
+    --color-success: #6b9b6b;
+    --color-error: #ff4444;
+    --color-disabled-bg: var(--color-sand);
+    --color-disabled-text: rgba(13, 94, 94, 0.5);
+}
+
+/* ============================================
+   Theme: Dark (Deep Teal)
+   ============================================ */
+[data-theme="dark"] {
+    /* Colors - Core Palette (same hues, dark context) */
+    --color-teal: #0D5E5E;
+    --color-deep-teal: #073838;
+    --color-marigold: #E8A832;
+    --color-rose: #E88FA0;
+    --color-cream: #FAF3E3;
+
+    /* Colors - Semantic */
+    --color-bg-base: var(--color-deep-teal);
+    --color-bg-surface: rgba(250, 243, 227, 0.05);
+    --color-bg-elevated: rgba(250, 243, 227, 0.08);
+    --color-bg-accent: var(--color-teal);
+    --color-bg-accent-secondary: var(--color-marigold);
+
+    /* Colors - Border */
+    --color-border: rgba(250, 243, 227, 0.15);
+    --color-border-subtle: rgba(250, 243, 227, 0.08);
+
+    /* Colors - Text */
+    --color-text-primary: var(--color-cream);
+    --color-text-secondary: rgba(250, 243, 227, 0.7);
+    --color-text-muted: rgba(250, 243, 227, 0.5);
+    --color-text-inverse: var(--color-deep-teal);
+    --color-text-on-accent: var(--color-cream);
+    --color-text-on-marigold: var(--color-deep-teal);
+
+    /* Colors - State */
+    --color-success: #6b9b6b;
+    --color-error: #ff4444;
+    --color-disabled-bg: rgba(250, 243, 227, 0.1);
+    --color-disabled-text: rgba(250, 243, 227, 0.4);
+}
+
+/* ============================================
+   Typography
+   ============================================ */
+:root {
+    /* Font Families */
+    --font-display: "Inter", system-ui, sans-serif;
+    --font-interface: "Geist Mono", "SF Mono", "Monaco", monospace;
+
+    /* Font Sizes */
+    --font-size-display: 40px;
+    --font-size-heading: 28px;
+    --font-size-subheading: 18px;
+    --font-size-body: 14px;
+    --font-size-caption: 12px;
+    --font-size-label: 11px;
+
+    /* Line Heights */
+    --line-height-display: 48px;
+    --line-height-heading: 34px;
+    --line-height-subheading: 22px;
+    --line-height-body: 18px;
+    --line-height-caption: 16px;
+
+    /* Font Weights */
+    --font-weight-bold: 700;
+    --font-weight-semibold: 600;
+    --font-weight-medium: 500;
+    --font-weight-regular: 400;
+
+    /* Letter Spacing */
+    --letter-spacing-label: 0.1em;
+}
+
+/* ============================================
+   Spacing
+   ============================================ */
+:root {
+    --space-xs: 8px;
+    --space-sm: 12px;
+    --space-md: 16px;
+    --space-lg: 20px;
+    --space-xl: 24px;
+    --space-2xl: 32px;
+    --space-3xl: 48px;
+}
+
+/* ============================================
+   Radii
+   ============================================ */
+:root {
+    --radius-sm: 6px;
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 16px;
+    --radius-full: 50%;
+}
+
+/* ============================================
+   Shadows
+   ============================================ */
+:root {
+    --shadow-node: 0 4px 16px rgba(13, 94, 94, 0.3);
+    --shadow-node-dark: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+/* ============================================
+   Visualizer Canvas
+   Read from JS at draw time — canvas can't resolve var()
+   ============================================ */
+:root,
+[data-theme="light"] {
+    --viz-bg: var(--color-sand);
+    --viz-grid: rgba(13, 94, 94, 0.2);
+    --viz-listener: var(--color-teal);
+    --viz-label: rgba(13, 94, 94, 0.6);
+}
+
+[data-theme="dark"] {
+    --viz-bg: #052b2b;
+    --viz-grid: rgba(250, 243, 227, 0.15);
+    --viz-listener: var(--color-cream);
+    --viz-label: rgba(250, 243, 227, 0.55);
+}
+
+/* ============================================
+   Transitions
+   ============================================ */
+:root {
+    --transition-fast: 0.15s ease;
+    --transition-base: 0.2s ease;
+    --transition-slow: 0.3s ease;
+}
+
+/* ============================================
+   Component Styles - Buttons
+   ============================================ */
+.btn {
+    font-family: var(--font-interface);
+    font-size: var(--font-size-body);
+    font-weight: var(--font-weight-medium);
+    padding: 12px 24px;
+    border-radius: var(--radius-md);
+    border: none;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+}
+
+.btn-primary {
+    background: var(--color-bg-accent);
+    color: var(--color-text-on-accent);
+}
+
+.btn-primary:hover {
+    filter: brightness(1.1);
+}
+
+.btn-accent {
+    background: var(--color-marigold);
+    color: var(--color-text-on-marigold);
+}
+
+.btn-accent:hover {
+    filter: brightness(1.05);
+}
+
+.btn-outline {
+    background: transparent;
+    border: 2px solid var(--color-border);
+    color: var(--color-text-primary);
+}
+
+.btn-outline:hover {
+    background: var(--color-bg-accent);
+    color: var(--color-text-on-accent);
+}
+
+.btn-disabled,
+.btn:disabled {
+    background: var(--color-disabled-bg);
+    color: var(--color-disabled-text);
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+/* Dark theme button adjustments */
+[data-theme="dark"] .btn-primary {
+    background: var(--color-cream);
+    color: var(--color-deep-teal);
+}
+
+[data-theme="dark"] .btn-outline {
+    border-color: rgba(250, 243, 227, 0.4);
+    color: var(--color-cream);
+}
+
+[data-theme="dark"] .btn-outline:hover {
+    background: var(--color-cream);
+    color: var(--color-deep-teal);
+}
+
+/* ============================================
+   Component Styles - Agent Session Cards
+   ============================================ */
+.agent-session {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-md);
+    background: var(--color-bg-surface);
+    border: 2px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    min-width: 280px;
+}
+
+.agent-session-indicator {
+    width: 48px;
+    height: 48px;
+    border-radius: var(--radius-full);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.agent-session-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.agent-session-name {
+    font-family: var(--font-interface);
+    font-size: var(--font-size-body);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-primary);
+}
+
+.agent-session-meta {
+    font-family: var(--font-interface);
+    font-size: var(--font-size-caption);
+    color: var(--color-text-muted);
+}
+
+/* Dark theme agent session */
+[data-theme="dark"] .agent-session {
+    background: var(--color-bg-elevated);
+    border-color: transparent;
+}
+
+/* ============================================
+   Component Styles - Source Nodes
+   ============================================ */
+.source-node {
+    width: 72px;
+    height: 72px;
+    border-radius: var(--radius-full);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    cursor: grab;
+    transition: all var(--transition-fast);
+    box-shadow: var(--shadow-node);
+}
+
+.source-node-icon {
+    font-family: var(--font-display);
+    font-size: 24px;
+    font-weight: var(--font-weight-bold);
+}
+
+.source-node-label {
+    font-family: var(--font-interface);
+    font-size: var(--font-size-label);
+    color: var(--color-text-inverse);
+    opacity: 0.8;
+}
+
+.source-node--default {
+    background: var(--color-teal);
+    border: 2px solid var(--color-teal);
+}
+
+.source-node--default .source-node-icon {
+    color: var(--color-cream);
+}
+
+.source-node--active {
+    background: var(--color-marigold);
+    border: 2px solid var(--color-marigold);
+}
+
+.source-node--active .source-node-icon {
+    color: var(--color-teal);
+}
+
+.source-node--idle {
+    background: var(--color-sand);
+    border: 2px solid var(--color-border-subtle);
+    opacity: 0.6;
+}
+
+.source-node--idle .source-node-icon {
+    color: var(--color-text-muted);
+}
+
+.source-node--disconnected {
+    background: transparent;
+    border: 2px dashed var(--color-border-subtle);
+    opacity: 0.4;
+    box-shadow: none;
+}
+
+.source-node--disconnected .source-node-icon {
+    color: var(--color-text-muted);
+}
+
+/* Dark theme source nodes */
+[data-theme="dark"] .source-node {
+    box-shadow: var(--shadow-node-dark);
+}
+
+[data-theme="dark"] .source-node--default {
+    background: rgba(232, 168, 50, 0.15);
+    border-color: var(--color-marigold);
+}
+
+[data-theme="dark"] .source-node--default .source-node-icon {
+    color: var(--color-marigold);
+}
+
+[data-theme="dark"] .source-node--active {
+    background: rgba(232, 143, 160, 0.15);
+    border-color: var(--color-rose);
+}
+
+[data-theme="dark"] .source-node--active .source-node-icon {
+    color: var(--color-rose);
+}
+
+[data-theme="dark"] .source-node--idle {
+    background: rgba(13, 94, 94, 0.3);
+    border-color: var(--color-teal);
+}
+
+[data-theme="dark"] .source-node--idle .source-node-icon {
+    color: var(--color-teal);
+}
+
+[data-theme="dark"] .source-node--disconnected {
+    background: rgba(250, 243, 227, 0.03);
+    border-color: rgba(250, 243, 227, 0.2);
+}
+
+/* ============================================
+   Component Styles - Tool Events
+   ============================================ */
+.tool-event {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: 10px 14px;
+    background: var(--color-bg-surface);
+    border-radius: var(--radius-sm);
+}
+
+.tool-event-badge {
+    font-family: var(--font-interface);
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-medium);
+    padding: 4px 8px;
+    border-radius: var(--radius-sm);
+    background: var(--color-bg-accent);
+    color: var(--color-text-on-accent);
+}
+
+.tool-event-name {
+    font-family: var(--font-interface);
+    font-size: var(--font-size-body);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-primary);
+}
+
+.tool-event-agent {
+    font-family: var(--font-interface);
+    font-size: var(--font-size-body);
+    color: var(--color-text-muted);
+}
+
+.tool-event-time {
+    font-family: var(--font-interface);
+    font-size: var(--font-size-body);
+    color: var(--color-text-muted);
+    margin-left: auto;
+}
+
+/* Dark theme tool events */
+[data-theme="dark"] .tool-event {
+    background: var(--color-bg-surface);
+}
+
+[data-theme="dark"] .tool-event-name {
+    color: var(--color-marigold);
+}
+
+/* ============================================
+   Component Styles - Panels
+   ============================================ */
+.panel {
+    padding: var(--space-lg);
+    border-radius: var(--radius-xl);
+}
+
+.panel--default {
+    background: var(--color-bg-surface);
+    border: 2px solid var(--color-border);
+}
+
+.panel--accent {
+    background: var(--color-bg-accent);
+    color: var(--color-text-on-accent);
+}
+
+.panel-title {
+    font-family: var(--font-interface);
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-label);
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-sm);
+}
+
+.panel--accent .panel-title {
+    color: rgba(250, 243, 227, 0.7);
+}
+
+.panel-content {
+    font-family: var(--font-interface);
+    font-size: var(--font-size-body);
+}
+
+/* Dark theme panels */
+[data-theme="dark"] .panel--default {
+    background: var(--color-bg-surface);
+    border-color: var(--color-border-subtle);
+}
+
+[data-theme="dark"] .panel--inverted {
+    background: var(--color-cream);
+    color: var(--color-deep-teal);
+}
+
+[data-theme="dark"] .panel--inverted .panel-title {
+    color: rgba(7, 56, 56, 0.6);
+}
+
+[data-theme="dark"] .panel--inverted .panel-content {
+    color: var(--color-deep-teal);
+}
+
+/* ============================================
+   Typography Utilities
+   ============================================ */
+.text-display {
+    font-family: var(--font-display);
+    font-size: var(--font-size-display);
+    font-weight: var(--font-weight-bold);
+    line-height: var(--line-height-display);
+    color: var(--color-text-primary);
+}
+
+.text-heading {
+    font-family: var(--font-display);
+    font-size: var(--font-size-heading);
+    font-weight: var(--font-weight-bold);
+    line-height: var(--line-height-heading);
+    color: var(--color-text-primary);
+}
+
+.text-subheading {
+    font-family: var(--font-display);
+    font-size: var(--font-size-subheading);
+    font-weight: var(--font-weight-semibold);
+    line-height: var(--line-height-subheading);
+    color: var(--color-text-primary);
+}
+
+.text-body {
+    font-family: var(--font-interface);
+    font-size: var(--font-size-body);
+    font-weight: var(--font-weight-regular);
+    line-height: var(--line-height-body);
+    color: var(--color-text-primary);
+}
+
+.text-caption {
+    font-family: var(--font-interface);
+    font-size: var(--font-size-caption);
+    font-weight: var(--font-weight-regular);
+    line-height: var(--line-height-caption);
+    color: var(--color-text-secondary);
+}
+
+.text-label {
+    font-family: var(--font-interface);
+    font-size: var(--font-size-label);
+    font-weight: var(--font-weight-semibold);
+    text-transform: uppercase;
+    letter-spacing: var(--letter-spacing-label);
+    color: var(--color-text-muted);
+}
+
+/* ============================================
+   Color Utilities
+   ============================================ */
+.bg-teal { background-color: var(--color-teal); }
+.bg-marigold { background-color: var(--color-marigold); }
+.bg-rose { background-color: var(--color-rose); }
+.bg-cream { background-color: var(--color-cream); }
+.bg-sand { background-color: var(--color-sand); }
+
+.text-teal { color: var(--color-teal); }
+.text-marigold { color: var(--color-marigold); }
+.text-rose { color: var(--color-rose); }
+.text-cream { color: var(--color-cream); }
+
+.border-teal { border-color: var(--color-teal); }
+.border-marigold { border-color: var(--color-marigold); }
+.border-rose { border-color: var(--color-rose); }

--- a/client/src/styles/main.css
+++ b/client/src/styles/main.css
@@ -1,59 +1,37 @@
 /* ============================================
-   Design Tokens
+   Import Design System
+   ============================================ */
+@import url('./design-system.css');
+
+/* ============================================
+   Legacy Design Tokens (being migrated)
    ============================================ */
 :root {
-    /* Colors - Background */
-    --color-bg-base: #000e14;
-    --color-bg-surface: #00111a;
-    --color-bg-elevated: #00141f;
-
-    /* Colors - Border */
-    --color-border: #2a2a3a;
-
-    /* Colors - Text */
-    --color-text-primary: #e0e0e0;
-    --color-text-secondary: #999;
-    --color-text-muted: #888;
-    --color-text-inverse: #0a0a0f;
-    --color-text-bright: #fff;
-
-    /* Colors - Accent */
-    --color-accent: #1a7a9e;
-    --color-accent-hover: #15678a;
+    /* Colors - Accent (mapped to design system) */
+    --color-accent: var(--color-teal);
+    --color-accent-hover: #0a4a4a;
 
     /* Colors - Semantic */
-    --color-success: #6b9b6b;
-    --color-error: #ff4444;
-    --color-tool: #ff6b6b;
+    --color-tool: var(--color-rose);
+    --color-text-bright: var(--color-text-primary);
 
-    /* Typography */
-    --font-mono:
-        "SF Mono", "Monaco", "Inconsolata", "Roboto Mono", monospace;
+    /* Typography - Legacy mappings */
+    --font-mono: var(--font-interface);
     --font-size-xs: 0.75em;
     --font-size-sm: 0.8em;
     --font-size-base: 0.85em;
     --font-size-md: 0.9em;
     --font-size-lg: 1.5em;
 
-    /* Spacing */
-    --space-xs: 8px;
-    --space-sm: 10px;
-    --space-md: 15px;
-    --space-lg: 20px;
-    --space-xl: 24px;
-
-    /* Radii */
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-full: 50%;
-
-    /* Transitions */
-    --transition-fast: 0.2s ease;
-    --transition-base: 0.3s ease;
-
     /* Layout */
     --sidebar-width: 300px;
     --container-max: 1400px;
+}
+
+/* Dark theme: marigold takes over as the accent (teal-on-teal lacks contrast) */
+[data-theme="dark"] {
+    --color-accent: var(--color-marigold);
+    --color-accent-hover: #d99a26;
 }
 
 /* ============================================
@@ -529,7 +507,7 @@ input[type="range"] {
 .sessions-list,
 .event-log {
     scrollbar-width: thin;
-    scrollbar-color: #2d3748 transparent;
+    scrollbar-color: var(--color-border-subtle) transparent;
 }
 
 .sessions-list::-webkit-scrollbar,
@@ -544,13 +522,13 @@ input[type="range"] {
 
 .sessions-list::-webkit-scrollbar-thumb,
 .event-log::-webkit-scrollbar-thumb {
-    background: #2d3748;
+    background: var(--color-border-subtle);
     border-radius: 3px;
 }
 
 .sessions-list::-webkit-scrollbar-thumb:hover,
 .event-log::-webkit-scrollbar-thumb:hover {
-    background: #4a5568;
+    background: var(--color-border);
 }
 
 /* ============================================

--- a/client/src/visualizer.ts
+++ b/client/src/visualizer.ts
@@ -344,14 +344,30 @@ export class Visualizer {
   private height = 0
 
   // Fixed font string to avoid CSS variable in canvas (which doesn't work)
-  private readonly FONT = "10px 'SF Mono', Monaco, Inconsolata, 'Roboto Mono', monospace"
+  private readonly FONT = "10px 'Geist Mono', 'SF Mono', Monaco, monospace"
   private readonly MAX_ACTIVE_PULSES = 180
 
   private resizeRafId: number | null = null
 
+  // Theme palette cached from CSS custom properties (canvas can't resolve var())
+  private palette = {
+    bg: '#052b2b',
+    grid: 'rgba(250, 243, 227, 0.15)',
+    listener: '#FAF3E3',
+    label: 'rgba(250, 243, 227, 0.55)',
+  }
+
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas
     this.ctx = canvas.getContext('2d', { alpha: false })!
+
+    this.readPalette()
+
+    // Re-read palette when the theme attribute flips
+    new MutationObserver(() => {
+      this.readPalette()
+      this.drawStatic()
+    }).observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] })
 
     // Use ResizeObserver with rAF to avoid "loop completed with undelivered notifications"
     new ResizeObserver(() => {
@@ -361,6 +377,17 @@ export class Visualizer {
         this.resize()
       })
     }).observe(this.canvas)
+  }
+
+  private readPalette(): void {
+    const styles = getComputedStyle(document.documentElement)
+    const read = (name: string, fallback: string) => styles.getPropertyValue(name).trim() || fallback
+    this.palette = {
+      bg: read('--viz-bg', this.palette.bg),
+      grid: read('--viz-grid', this.palette.grid),
+      listener: read('--viz-listener', this.palette.listener),
+      label: read('--viz-label', this.palette.label),
+    }
   }
 
   private resize(): void {
@@ -397,11 +424,11 @@ export class Visualizer {
     const { centerX, centerY, maxRadius } = this.getRadarGeometry()
 
     // Clear canvas
-    ctx.fillStyle = '#00141f'
+    ctx.fillStyle = this.palette.bg
     ctx.fillRect(0, 0, this.width, this.height)
 
     // Draw concentric circles (distance zones)
-    ctx.strokeStyle = 'rgba(42, 42, 58, 0.5)'
+    ctx.strokeStyle = this.palette.grid
     ctx.lineWidth = 1
     ;[0.25, 0.5, 0.75, 1].forEach((pct) => {
       ctx.beginPath()
@@ -418,13 +445,13 @@ export class Visualizer {
     ctx.stroke()
 
     // Draw listener indicator at center
-    ctx.fillStyle = '#fff'
+    ctx.fillStyle = this.palette.listener
     ctx.beginPath()
     ctx.arc(centerX, centerY, 6, 0, Math.PI * 2)
     ctx.fill()
 
     // Listener label - use literal font string, not CSS variable
-    ctx.fillStyle = 'rgba(136, 136, 136, 0.7)'
+    ctx.fillStyle = this.palette.label
     ctx.font = this.FONT
     ctx.textAlign = 'center'
     ctx.fillText('LISTENER', centerX, centerY + 22)


### PR DESCRIPTION
Adopts the cream/teal/marigold design system in the web client.

- New `design-system.css` with tokens and component styles for light (cream) and dark (deep teal) themes
- `main.css` migrated to design system tokens; legacy tokens mapped during transition
- Theme follows system preference via a `data-theme` attribute set before first paint (with live switching), so the dark component styles apply — replaces the token-only `prefers-color-scheme` block
- Dark theme remaps the legacy accent to marigold (teal-on-teal lacked contrast)
- Visualizer canvas now reads its palette from CSS tokens (`--viz-*`) and re-reads on theme change, replacing hardcoded old-palette colors
- Geist Mono + Inter loaded from Google Fonts
- Fixes light-mode bug where `--color-text-bright` mapped to cream (invisible title/session IDs)

Verified both themes in-browser with live sessions and events.