### PR TITLE
refactor: extract server package and discriminate the wire protocol

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -1,4 +1,5 @@
 import './styles/main.css'
+import { PROTOCOL_VERSION } from '@bingbong/protocol'
 import type { EnrichedEvent, Session } from './types'
 import { AudioEngine } from './audio-engine'
 import { Connection } from './connection'
@@ -251,6 +252,11 @@ function handleMessage(data: unknown): void {
 
   // Handle init message with existing sessions
   if (msg.type === 'init' && Array.isArray(msg.sessions)) {
+    if (typeof msg.protocol_version === 'number' && msg.protocol_version !== PROTOCOL_VERSION) {
+      console.warn(
+        `[bingbong] Server speaks protocol v${msg.protocol_version}, client expects v${PROTOCOL_VERSION}`,
+      )
+    }
     // Full cleanup chain on reconnect
     sessions.clear()
     sourceOverlay?.clearSources()
@@ -267,8 +273,13 @@ function handleMessage(data: unknown): void {
     return
   }
 
-  // Handle regular event
-  handleEvent(msg as unknown as EnrichedEvent)
+  // Handle enriched event
+  if (msg.type === 'event' && msg.event && typeof msg.event === 'object') {
+    handleEvent(msg.event as EnrichedEvent)
+    return
+  }
+
+  console.warn('[bingbong] Ignoring unknown server message:', msg.type)
 }
 
 // ============================================

--- a/apps/client/src/types.ts
+++ b/apps/client/src/types.ts
@@ -1,6 +1,7 @@
 export type {
   BingbongEvent,
   EnrichedEvent,
+  EventMessage,
   HealthResponse,
   InitMessage,
   ServerMessage,

--- a/bun.lock
+++ b/bun.lock
@@ -19,10 +19,17 @@
       "name": "@bingbong/cli",
       "dependencies": {
         "@bingbong/protocol": "file:../protocol",
+        "@bingbong/server": "file:../server",
       },
     },
     "packages/protocol": {
       "name": "@bingbong/protocol",
+    },
+    "packages/server": {
+      "name": "@bingbong/server",
+      "dependencies": {
+        "@bingbong/protocol": "file:../protocol",
+      },
     },
   },
   "packages": {
@@ -31,6 +38,8 @@
     "@bingbong/client": ["@bingbong/client@workspace:apps/client"],
 
     "@bingbong/protocol": ["@bingbong/protocol@workspace:packages/protocol"],
+
+    "@bingbong/server": ["@bingbong/server@workspace:packages/server"],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -163,5 +172,7 @@
     "@bingbong/cli/@bingbong/protocol": ["@bingbong/protocol@file:packages/protocol", {}],
 
     "@bingbong/client/@bingbong/protocol": ["@bingbong/protocol@file:packages/protocol", {}],
+
+    "@bingbong/server/@bingbong/protocol": ["@bingbong/protocol@file:packages/protocol", {}],
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,10 @@
       "resolved": "packages/protocol",
       "link": true
     },
+    "node_modules/@bingbong/server": {
+      "resolved": "packages/server",
+      "link": true
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.12",
       "cpu": [
@@ -355,11 +359,18 @@
     "packages/cli": {
       "name": "@bingbong/cli",
       "dependencies": {
-        "@bingbong/protocol": "file:../protocol"
+        "@bingbong/protocol": "file:../protocol",
+        "@bingbong/server": "file:../server"
       }
     },
     "packages/protocol": {
       "name": "@bingbong/protocol"
+    },
+    "packages/server": {
+      "name": "@bingbong/server",
+      "dependencies": {
+        "@bingbong/protocol": "file:../protocol"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "apps/client/",
     "packages/cli/",
     "packages/protocol/",
+    "packages/server/",
     "agents/"
   ],
   "scripts": {

--- a/packages/cli/bin/cli.ts
+++ b/packages/cli/bin/cli.ts
@@ -6,7 +6,9 @@
  * Unified command to run the Bingbong server and client.
  */
 
-import { startServer, type RuntimeLogger } from "../src/server";
+import { startServer, type RuntimeLogger } from "@bingbong/server";
+import clientIndex from "../../../apps/client/index.html";
+import { TerminalLayoutLogger } from "../src/runtime-logger";
 
 const VERSION = "0.1.9";
 
@@ -164,8 +166,14 @@ async function main() {
     process.exit(1);
   }
 
-  // Start the server
-  const runtime = await startServer(args.port);
+  // Start the server: terminal rendering and the browser client bundle
+  // are CLI concerns, injected into the transport-only server package.
+  const runtime = await startServer({
+    port: args.port,
+    version: VERSION,
+    client: clientIndex,
+    createLogger: (ctx) => new TerminalLayoutLogger(ctx),
+  });
   activeLogger = runtime.logger;
 
   function shutdown() {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@bingbong/protocol": "file:../protocol"
+    "@bingbong/protocol": "file:../protocol",
+    "@bingbong/server": "file:../server"
   }
 }

--- a/packages/cli/src/runtime-logger.ts
+++ b/packages/cli/src/runtime-logger.ts
@@ -1,35 +1,10 @@
-export interface RuntimeStats {
-  sessionCount: number;
-  clientCount: number;
-  eventCount: number;
-}
-
-export type RuntimeStatsProvider = () => RuntimeStats;
-
-export interface RuntimeLogger {
-  info(message: string): void;
-  error(message: string, err?: unknown): void;
-  dispose(): void;
-}
+import type {
+  RuntimeLogger,
+  RuntimeStats,
+  RuntimeStatsProvider,
+} from "@bingbong/server";
 
 const MAX_EVENT_LOG_LINES = 1000;
-
-export class PlainLogger implements RuntimeLogger {
-  info(message: string) {
-    console.log(message);
-  }
-
-  error(message: string, err?: unknown) {
-    if (err !== undefined) {
-      console.error(message, err);
-      return;
-    }
-
-    console.error(message);
-  }
-
-  dispose() {}
-}
 
 interface TerminalLayoutLoggerOptions {
   port: number;

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -12,7 +12,13 @@ import {
   type RuntimeStats,
 } from "./runtime-logger";
 import { SessionRegistry } from "./session-registry";
-import type { BingbongEvent, EnrichedEvent } from "@bingbong/protocol";
+import {
+  PROTOCOL_VERSION,
+  type BingbongEvent,
+  type EnrichedEvent,
+  type EventMessage,
+  type InitMessage,
+} from "@bingbong/protocol";
 
 const VERSION = "0.1.9";
 export type { RuntimeLogger } from "./runtime-logger";
@@ -59,7 +65,7 @@ export async function startServer(port: number): Promise<StartServerResult> {
   }
 
   function broadcast(event: EnrichedEvent) {
-    const message = JSON.stringify(event);
+    const message = JSON.stringify({ type: "event", event } satisfies EventMessage);
     for (const client of wsClients) {
       try {
         client.send(message);
@@ -164,8 +170,9 @@ export async function startServer(port: number): Promise<StartServerResult> {
         ws.send(
           JSON.stringify({
             type: "init",
+            protocol_version: PROTOCOL_VERSION,
             sessions: sessionRegistry.snapshots(),
-          }),
+          } satisfies InitMessage),
         );
       },
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -26,12 +26,20 @@ export interface SessionSnapshot {
   last_seen?: string;
 }
 
+export const PROTOCOL_VERSION = 1;
+
 export interface InitMessage {
   type: "init";
+  protocol_version: number;
   sessions: SessionSnapshot[];
 }
 
-export type ServerMessage = InitMessage | EnrichedEvent;
+export interface EventMessage {
+  type: "event";
+  event: EnrichedEvent;
+}
+
+export type ServerMessage = InitMessage | EventMessage;
 
 export interface HealthResponse {
   name: string;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@bingbong/server",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "types": "./src/index.ts",
+  "dependencies": {
+    "@bingbong/protocol": "file:../protocol"
+  }
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,0 +1,12 @@
+export {
+  startServer,
+  type StartServerOptions,
+  type StartServerResult,
+} from "./server";
+export {
+  PlainLogger,
+  type RuntimeLogger,
+  type RuntimeStats,
+  type RuntimeStatsProvider,
+} from "./logger";
+export { SessionRegistry } from "./session-registry";

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -1,0 +1,30 @@
+export interface RuntimeStats {
+  sessionCount: number;
+  clientCount: number;
+  eventCount: number;
+}
+
+export type RuntimeStatsProvider = () => RuntimeStats;
+
+export interface RuntimeLogger {
+  info(message: string): void;
+  error(message: string, err?: unknown): void;
+  dispose(): void;
+}
+
+export class PlainLogger implements RuntimeLogger {
+  info(message: string) {
+    console.log(message);
+  }
+
+  error(message: string, err?: unknown) {
+    if (err !== undefined) {
+      console.error(message, err);
+      return;
+    }
+
+    console.error(message);
+  }
+
+  dispose() {}
+}

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,16 +1,17 @@
 /**
  * Bingbong Server
  *
- * Receives events from Claude Code hooks and broadcasts them
- * to connected frontend clients for audio rendering.
+ * Receives events from agent hooks and broadcasts them to connected
+ * clients for audio rendering. Transport only — terminal rendering and
+ * client assets are injected by the host (e.g. the CLI).
  */
 
-import clientIndex from "../../../apps/client/index.html";
 import {
-  TerminalLayoutLogger,
+  PlainLogger,
   type RuntimeLogger,
   type RuntimeStats,
-} from "./runtime-logger";
+  type RuntimeStatsProvider,
+} from "./logger";
 import { SessionRegistry } from "./session-registry";
 import {
   PROTOCOL_VERSION,
@@ -20,16 +21,30 @@ import {
   type InitMessage,
 } from "@bingbong/protocol";
 
-const VERSION = "0.1.9";
-export type { RuntimeLogger } from "./runtime-logger";
+export interface LoggerContext {
+  port: number;
+  version: string;
+  getStats: RuntimeStatsProvider;
+}
 
-interface StartServerResult {
+export interface StartServerOptions {
+  port: number;
+  version: string;
+  /** Bun HTML bundle served at "/" (e.g. the browser client's index.html import). */
+  client?: unknown;
+  createLogger?: (ctx: LoggerContext) => RuntimeLogger;
+}
+
+export interface StartServerResult {
   server: Bun.Server;
   logger: RuntimeLogger;
   dispose(): void;
 }
 
-export async function startServer(port: number): Promise<StartServerResult> {
+export async function startServer(
+  options: StartServerOptions,
+): Promise<StartServerResult> {
+  const { port, version } = options;
   const sessionRegistry = new SessionRegistry();
   const wsClients = new Set<WebSocket>();
 
@@ -37,11 +52,9 @@ export async function startServer(port: number): Promise<StartServerResult> {
     return sessionRegistry.stats(wsClients.size);
   }
 
-  const logger = new TerminalLayoutLogger({
-    port,
-    version: VERSION,
-    getStats: getRuntimeStats,
-  });
+  const logger = options.createLogger
+    ? options.createLogger({ port, version, getStats: getRuntimeStats })
+    : new PlainLogger();
 
   function logInfo(message: string) {
     logger.info(message);
@@ -84,9 +97,7 @@ export async function startServer(port: number): Promise<StartServerResult> {
 
   const server = Bun.serve({
     port,
-    routes: {
-      "/": clientIndex,
-    },
+    routes: options.client ? { "/": options.client } : {},
 
     async fetch(req) {
       const url = new URL(req.url);
@@ -148,7 +159,7 @@ export async function startServer(port: number): Promise<StartServerResult> {
         return new Response(
           JSON.stringify({
             name: "Bingbong Server",
-            version: VERSION,
+            version,
             sessions: getRuntimeStats().sessionCount,
             clients: wsClients.size,
           }),

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -3,7 +3,7 @@ import type {
   BingbongEvent,
   SessionSnapshot,
 } from "@bingbong/protocol";
-import type { RuntimeStats } from "./runtime-logger";
+import type { RuntimeStats } from "./logger";
 
 interface SessionRecord extends Omit<SessionSnapshot, "first_seen" | "last_seen"> {
   first_seen: Date;

--- a/scripts/check-version-parity.sh
+++ b/scripts/check-version-parity.sh
@@ -25,23 +25,20 @@ need_cmd node
 pkg_version="$(node -p "require('./package.json').version")"
 lock_version="$(node -e "const l=require('./package-lock.json'); process.stdout.write((l.version||l.packages?.['']?.version||''));")"
 cli_version="$(node -e "const fs=require('fs'); const m=fs.readFileSync('packages/cli/bin/cli.ts','utf8').match(/const VERSION = \"([^\"]+)\"/); process.stdout.write(m?.[1]||'');")"
-server_version="$(node -e "const fs=require('fs'); const m=fs.readFileSync('packages/cli/src/server.ts','utf8').match(/const VERSION = \"([^\"]+)\"/); process.stdout.write(m?.[1]||'');")"
-
-if [[ -z "$pkg_version" || -z "$lock_version" || -z "$cli_version" || -z "$server_version" ]]; then
+if [[ -z "$pkg_version" || -z "$lock_version" || -z "$cli_version" ]]; then
   echo "[version-parity] FAIL: unable to read package versions" >&2
   exit 1
 fi
 
-if [[ "$pkg_version" != "$lock_version" || "$pkg_version" != "$cli_version" || "$pkg_version" != "$server_version" ]]; then
+if [[ "$pkg_version" != "$lock_version" || "$pkg_version" != "$cli_version" ]]; then
   echo "[version-parity] FAIL: versions disagree" >&2
   echo "[version-parity] package.json: $pkg_version" >&2
   echo "[version-parity] package-lock.json: $lock_version" >&2
   echo "[version-parity] packages/cli/bin/cli.ts: $cli_version" >&2
-  echo "[version-parity] packages/cli/src/server.ts: $server_version" >&2
   exit 1
 fi
 
-echo "[version-parity] package.json == package-lock.json == CLI/server constants == $pkg_version"
+echo "[version-parity] package.json == package-lock.json == CLI constant == $pkg_version"
 
 if [[ -n "$TAG_INPUT" ]]; then
   tag_version="$(normalize_tag "$TAG_INPUT")"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -77,11 +77,11 @@ fi
 new_version="$(node -p "require('./package.json').version")"
 tag="v${new_version}"
 
-echo "[release] updating embedded CLI/server version constants"
+echo "[release] updating embedded CLI version constant"
 node -e '
 const fs = require("fs");
 const version = process.argv[1];
-for (const path of ["packages/cli/bin/cli.ts", "packages/cli/src/server.ts"]) {
+for (const path of ["packages/cli/bin/cli.ts"]) {
   const source = fs.readFileSync(path, "utf8");
   const next = source.replace(/const VERSION = "[^"]+";/, `const VERSION = "${version}";`);
   if (next === source) {
@@ -96,7 +96,7 @@ echo "[release] verifying version parity"
 scripts/check-version-parity.sh "$tag"
 
 echo "[release] committing version bump"
-git add package.json package-lock.json packages/cli/bin/cli.ts packages/cli/src/server.ts
+git add package.json package-lock.json packages/cli/bin/cli.ts
 git commit -m "$new_version"
 git tag "$tag"
 


### PR DESCRIPTION
Follow-up to #36. Two changes that were flagged in review as cheap now and expensive later:

## Server package split

The server transport now lives in `@bingbong/server` (`packages/server`), leaving `@bingbong/cli` as the thin distribution layer. The layering inversion is gone: the server package no longer imports `apps/client/index.html` or constructs the terminal UI — the CLI injects both.

- `startServer(options)` takes `port`, `version`, an optional `client` bundle served at `/`, and an optional `createLogger` factory; it defaults to `PlainLogger`, so the server runs headless out of the box.
- `SessionRegistry` and the `RuntimeLogger` contract (+ `PlainLogger`) moved to `packages/server`; `TerminalLayoutLogger` (the TUI) stays in the CLI and now implements the server's interface.
- The server no longer embeds a `VERSION` constant (the CLI passes it), so `check-version-parity.sh` and `release.sh` now track only `cli.ts`.

```mermaid
flowchart TB
  CLI[packages/cli/bin/cli.ts] -->|"startServer({ client, createLogger })"| Server[packages/server]
  CLI --> TUI[packages/cli runtime-logger]
  TUI -.implements RuntimeLogger.-> Server
  Server --> Protocol[packages/protocol]
  Client[apps/client] --> Protocol
```

## Protocol: discriminated union + version

`ServerMessage` is now a real discriminated union: events are broadcast as `{ type: "event", event: EnrichedEvent }` instead of bare enriched events, and the init message carries `protocol_version` (`PROTOCOL_VERSION = 1`). The client warns on version mismatch and ignores unknown message types instead of treating anything without `type: "init"` as an event. Breaking on the wire, but done now while there is exactly one client.

## Verification

- `scripts/check-version-parity.sh`
- `bun run typecheck:client`
- `bun build ./packages/cli/bin/cli.ts --compile` + live boot: `/health`, `/sessions`, `/` serves the client, SIGINT exits cleanly
- WS shape assertions against the live binary: init carries `type/protocol_version/sessions`, broadcasts carry `type: "event"` with enriched payload
- `bingbong test` against the live binary
- `scripts/test-local-release.sh` (prebuilt install path, embedded UI assets)
