### PR TITLE
derive human-readable session labels from cwd

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -85,7 +85,7 @@ function updateUI(): void {
         }),
         createElement('div', { class: 'session-info' }, [
           createElement('div', { class: 'session-id', title: s.session_id }, [
-            s.session_id.slice(0, 12) + '...',
+            s.label || s.session_id.slice(0, 12) + '...',
           ]),
           createElement('div', { class: 'session-meta' }, [
             `${s.machine_id || 'Unknown'} • ${s.event_count || 0} events`,
@@ -217,6 +217,7 @@ function handleEvent(event: EnrichedEvent): void {
     const sessionData: Session = {
       session_id: event.session_id,
       machine_id: event.machine_id,
+      label: event.session_label,
       pan: event.pan,
       index: event.session_index,
       color: event.color,

--- a/apps/client/src/visualizer.ts
+++ b/apps/client/src/visualizer.ts
@@ -133,9 +133,21 @@ export class SourceOverlay {
 
   createSource(session: Session): void {
     const key = `${session.machine_id}:${session.session_id}`
+    const labelText = session.label || session.session_id.slice(0, 8)
+    const title = session.label
+      ? `${session.label} — ${session.session_id}`
+      : session.session_id || 'Unknown session'
 
-    // Skip if already exists
-    if (this.sources.has(key)) {
+    // Already exists — refresh the label (it can upgrade from an id
+    // fallback to a project name once the server sees a cwd)
+    const existing = this.sources.get(key)
+    if (existing) {
+      const labelEl = existing.el.querySelector('.source-label')
+      if (labelEl && labelEl.textContent !== labelText) {
+        labelEl.textContent = labelText
+        existing.el.title = title
+      }
+      existing.session = session
       return
     }
 
@@ -147,7 +159,7 @@ export class SourceOverlay {
     const el = document.createElement('div')
     el.className = 'source-circle'
     el.dataset.session = key
-    el.title = session.session_id || 'Unknown session'
+    el.title = title
     el.style.setProperty('--session-color', session.color)
 
     // Icon and label
@@ -157,7 +169,7 @@ export class SourceOverlay {
 
     const label = document.createElement('div')
     label.className = 'source-label'
-    label.textContent = session.session_id.slice(0, 8)
+    label.textContent = labelText
 
     el.appendChild(icon)
     el.appendChild(label)

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -13,11 +13,13 @@ export interface EnrichedEvent extends BingbongEvent {
   pan: number;
   session_index: number;
   color: string;
+  session_label?: string;
 }
 
 export interface SessionSnapshot {
   session_id: string;
   machine_id: string;
+  label?: string;
   pan: number;
   index: number;
   color: string;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -68,9 +68,9 @@ export async function startServer(
     const result = sessionRegistry.enrich(event);
 
     if (result.createdSession) {
-      const { key, index, pan } = result.createdSession;
+      const { key, label, index, pan } = result.createdSession;
       logInfo(
-        `[Session] New session: ${key} (index=${index}, pan=${pan.toFixed(2)})`,
+        `[Session] New session: ${label} [${key}] (index=${index}, pan=${pan.toFixed(2)})`,
       );
     }
 

--- a/packages/server/src/session-registry.ts
+++ b/packages/server/src/session-registry.ts
@@ -8,10 +8,14 @@ import type { RuntimeStats } from "./logger";
 interface SessionRecord extends Omit<SessionSnapshot, "first_seen" | "last_seen"> {
   first_seen: Date;
   last_seen: Date;
+  label: string;
+  /** True once the label came from a cwd, false while it's an id fallback. */
+  label_from_cwd: boolean;
 }
 
 interface SessionCreation {
   key: string;
+  label: string;
   index: number;
   pan: number;
 }
@@ -44,16 +48,27 @@ export class SessionRegistry {
     session.last_seen = new Date();
     session.event_count++;
 
+    // Upgrade an id-fallback label once a cwd shows up
+    if (!session.label_from_cwd) {
+      const derived = this.deriveLabel(event.cwd, event.session_id);
+      if (derived.fromCwd) {
+        session.label = derived.label;
+        session.label_from_cwd = true;
+      }
+    }
+
     return {
       event: {
         ...event,
         pan: session.pan,
         session_index: session.index,
         color: session.color,
+        session_label: session.label,
       },
       createdSession: createdSession
         ? {
             key,
+            label: session.label,
             index: session.index,
             pan: session.pan,
           }
@@ -65,6 +80,7 @@ export class SessionRegistry {
     return Array.from(this.sessions.values()).map((session) => ({
       session_id: session.session_id,
       machine_id: session.machine_id,
+      label: session.label,
       pan: session.pan,
       index: session.index,
       color: session.color,
@@ -113,9 +129,13 @@ export class SessionRegistry {
     const pan =
       index === 0 ? 0 : ((index % 2 === 1 ? -1 : 1) * Math.ceil(index / 2)) / 5;
 
+    const { label, fromCwd } = this.deriveLabel(event.cwd, event.session_id);
+
     const session: SessionRecord = {
       session_id: event.session_id,
       machine_id: event.machine_id,
+      label,
+      label_from_cwd: fromCwd,
       first_seen: new Date(),
       last_seen: new Date(),
       event_count: 0,
@@ -127,5 +147,35 @@ export class SessionRegistry {
     this.sessions.set(key, session);
 
     return { key, session, createdSession: true };
+  }
+
+  /**
+   * Human-readable session label: the cwd's directory name, suffixed
+   * with a counter when another active session already claimed it
+   * (e.g. two agents in the same repo). Falls back to a short id
+   * prefix until an event carrying a cwd arrives.
+   */
+  private deriveLabel(
+    cwd: unknown,
+    sessionId: string,
+  ): { label: string; fromCwd: boolean } {
+    const base =
+      typeof cwd === "string"
+        ? cwd.replace(/[\\/]+$/, "").split(/[\\/]/).pop() ?? ""
+        : "";
+
+    if (!base) {
+      return { label: sessionId.slice(0, 8), fromCwd: false };
+    }
+
+    const taken = new Set(
+      Array.from(this.sessions.values(), (session) => session.label),
+    );
+    let label = base;
+    for (let n = 2; taken.has(label); n++) {
+      label = `${base} (${n})`;
+    }
+
+    return { label, fromCwd: true };
   }
 }


### PR DESCRIPTION
Sessions were labeled with raw UUIDs, truncated to illegible fragments like `7004704b-d06...` in the session list and `7004704b` in the radar overlay.

All agent integrations (Claude Code hooks, opencode, pi) already send `cwd` with each event, so the server now derives a label from the project directory name and carries it through the protocol:

- session registry derives `label` from the cwd basename, falling back to a short id prefix when no cwd has been seen yet, and upgrading in place once one arrives
- concurrent sessions in the same project disambiguate as `bingbong`, `bingbong (2)`, ...
- `SessionSnapshot.label` and `EnrichedEvent.session_label` are additive optional fields, so no protocol version bump
- session list and radar overlay render the label, with the full session id in the hover tooltip; overlay labels refresh when a fallback label upgrades
- terminal log includes the label on new sessions

Verified end-to-end against a live server: normal labeling, same-project disambiguation, no-cwd fallback, and late-cwd upgrade all confirmed via `/sessions` and in the browser UI.