### PR TITLE
sync agent integrations with current harness event apis

### DIFF
--- a/.claude/skills/sync-agent-events/SKILL.md
+++ b/.claude/skills/sync-agent-events/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: sync-agent-events
+description: Audit bingbong's agent-harness integrations (Claude Code, Cursor, OpenCode, pi) against upstream event/hook APIs, report drift, and apply updates. Use when asked to check whether agent integrations are up to date, sync agent events, or when adding support for new harness events.
+---
+
+# Sync agent events
+
+Bingbong integrates with four agent harnesses. Each ships events differently and
+each drifts over time. This skill re-runs the upstream audit and updates the
+integrations plus `agents/event-coverage.md`.
+
+## Files that define bingbong's side
+
+| File | Role |
+|---|---|
+| `packages/cli/src/install-hooks.ts` | `CLAUDE_EVENTS` + `CURSOR_EVENTS` hook registration lists |
+| `packages/cli/src/emit.ts` | `CURSOR_EVENT_MAP` (camelCase → canonical), session-id + tool_response normalization |
+| `agents/opencode/plugins/bingbong.js` | OpenCode plugin: `EVENT_TYPE_MAP`, `IGNORED_PREFIXES`, tool hook shapes |
+| `agents/pi/extensions/bingbong.ts` | pi extension: `EVENT_TYPE_MAP`, `on(...)` subscriptions |
+| `apps/client/src/config.ts` | `SOUND_CONFIG` — canonical event types → sounds |
+| `packages/protocol/src/index.ts` | `BingbongEvent` wire shape |
+| `agents/event-coverage.md` | Coverage matrix, mapping decisions, audit history |
+
+## Procedure
+
+1. **Read `agents/event-coverage.md`** for the current baseline, the
+   canonical vocabulary, and the list of deliberately-skipped events (don't
+   re-propose those without a reason).
+
+2. **Research upstream, one subagent per harness, in parallel.** Give each
+   agent the current registered/mapped event list and ask for exact event
+   names, payload field names, schema changes, and deprecations/renames:
+   - **Claude Code** (closed source — use docs): fetch
+     https://code.claude.com/docs/en/hooks.md. Check: hook event list, matcher
+     support, stdin payload fields (`tool_response` vs `tool_output`), settings
+     schema for `{matcher, hooks: [{type: "command", command}]}` entries.
+   - **Cursor** (closed source — use docs): fetch https://cursor.com/docs/hooks
+     and https://cursor.com/changelog. Check: hook names (camelCase),
+     hooks.json `version`, stdin fields (`conversation_id`), exit-code
+     semantics (exit 2 blocks — bingbong must always exit 0).
+   - **OpenCode** (open source): read
+     `github.com/sst/opencode` `packages/plugin/src/index.ts` (hook
+     interface) and `packages/schema/src/` (bus event types). Docs at
+     opencode.ai/docs/plugins have been stale before — trust source over docs.
+   - **pi** (open source): read `github.com/earendil-works/pi`
+     `packages/coding-agent/src/core/extensions/types.ts` (`ExtensionEvent`
+     union), `docs/extensions.md`, and `CHANGELOG.md` for breaking changes.
+     Note: repo/npm moved from badlogic/pi-mono / `@mariozechner/*` in 2026.
+
+3. **Diff findings against the matrix.** Classify each delta:
+   - New event worth a sound → add to registration/subscription + mapping, and
+     add a `SOUND_CONFIG` entry if it's a new canonical type (notes must exist
+     in `NOTE_FREQ`).
+   - New event that's noisy/meta → add to the skipped list in the matrix with a
+     one-line reason (for OpenCode, consider `IGNORED_PREFIXES`).
+   - Renamed/removed event → update integration; never leave dead
+     subscriptions (they fail silently).
+   - Payload shape change → fix extraction (session id fields, tool arg
+     shapes) in the affected integration.
+
+4. **Guard rails when applying changes:**
+   - Emitters must never block a harness: always exit 0 / swallow errors.
+   - Avoid double sounds: when two upstream events signal the same thing
+     (e.g. deprecated + replacement both firing), dedupe with a time window —
+     see `isDuplicateStop` in the OpenCode plugin and pi extension.
+   - Keep `original_event_type` when normalizing a native name.
+   - Old harness versions still exist: prefer additive handling (subscribe to
+     both old and new events with dedupe) over hard cutovers.
+
+5. **Verify:** `bun run typecheck:client`, `bun run build:client`, and smoke
+   the emit path:
+   `echo '{"session_id":"test"}' | bun run packages/cli/bin/cli.ts emit PreToolUse`
+   (with a server running, or assert no crash without one). `test-events.sh`
+   exercises the server end-to-end.
+
+6. **Record the audit:** update the per-harness sections and append a row to
+   the audit-history table in `agents/event-coverage.md` with today's date,
+   even when there is no drift ("no changes" is a valid, useful entry).

--- a/agents/event-coverage.md
+++ b/agents/event-coverage.md
@@ -1,0 +1,126 @@
+# Agent harness event coverage
+
+Last audited: **2026-07-19**
+
+This document is the source of truth for which upstream harness events bingbong
+consumes, how they map to bingbong's canonical event vocabulary, and where each
+harness's authoritative event list lives. Re-audit with the `/sync-agent-events`
+skill (see `.claude/skills/sync-agent-events/SKILL.md`).
+
+## Canonical event vocabulary
+
+The server and client key sounds/visuals off these `event_type` values
+(see `apps/client/src/config.ts` and `apps/client/src/audio-engine.ts`):
+
+`SessionStart`, `SessionEnd`, `Stop`, `StopFailure`, `SubagentStart`,
+`SubagentStop`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`,
+`PreCompact`, `PostCompact`, `UserPromptSubmit`, `Notification`,
+`PermissionRequest`, `PermissionDenied`, `TaskCreated`, `TaskCompleted`,
+`TeammateIdle`, `Setup`
+
+`PreToolUse`/`PostToolUse` additionally use `tool_name` to pick tool-specific
+sounds. Unknown event types fall back to the default blip. When an integration
+maps a harness-native event to a canonical type, it preserves the native name in
+`original_event_type` (top-level for the CLI emit path, inside `tool_output` for
+the OpenCode/pi integrations).
+
+---
+
+## Claude Code
+
+- **Integration:** `bingbong emit <Event>` hooks written to `~/.claude/settings.json` by `packages/cli/src/install-hooks.ts` (`CLAUDE_EVENTS`).
+- **Source of truth:** https://code.claude.com/docs/en/hooks.md (hooks reference; not open source).
+- **Payload notes:** common fields `session_id`, `transcript_path`, `cwd`, `hook_event_name`; tool events carry `tool_name`, `tool_input`, and `tool_response` (normalized to `tool_output` in `emit.ts`). `bingbong emit` always exits 0, so hooks can never block actions.
+
+**Registered (19):** PreToolUse, PostToolUse, PostToolUseFailure, SessionStart,
+SessionEnd, Stop, StopFailure, SubagentStart, SubagentStop, PermissionRequest,
+PermissionDenied, Notification, PreCompact, PostCompact, TaskCreated,
+TaskCompleted, TeammateIdle, Setup, UserPromptSubmit — all pass through as-is
+(names are already canonical).
+
+**Known upstream, deliberately skipped (too noisy / not audibly useful — each
+hook spawns a process):** PostToolBatch, FileChanged, CwdChanged, ConfigChange,
+InstructionsLoaded, WorktreeCreate, WorktreeRemove, Elicitation,
+ElicitationResult, MessageDisplay, UserPromptExpansion.
+
+## Cursor
+
+- **Integration:** `bingbong emit <event>` hooks written to `~/.cursor/hooks.json` (`version: 1`) by `install-hooks.ts` (`CURSOR_EVENTS`); camelCase names normalized to canonical types by `CURSOR_EVENT_MAP` in `packages/cli/src/emit.ts`.
+- **Source of truth:** https://cursor.com/docs/hooks + https://cursor.com/changelog (not open source).
+- **Payload notes:** session identity is `conversation_id` (normalized in `emit.ts`); `session_id` only on sessionStart/sessionEnd. Exit code 2 from a hook blocks actions — `bingbong emit` always exits 0.
+
+| Cursor event | Canonical type | tool_name |
+|---|---|---|
+| sessionStart / sessionEnd | SessionStart / SessionEnd | — |
+| beforeShellExecution / afterShellExecution | PreToolUse / PostToolUse | Bash |
+| beforeMCPExecution / afterMCPExecution | PreToolUse / PostToolUse | from payload |
+| beforeReadFile | PreToolUse | Read |
+| afterFileEdit | PostToolUse | Edit |
+| beforeSubmitPrompt | UserPromptSubmit | — |
+| postToolUseFailure | PostToolUseFailure | from payload |
+| subagentStart / subagentStop | SubagentStart / SubagentStop | — |
+| preCompact | PreCompact | — |
+| stop | Stop | — |
+| afterAgentResponse / afterAgentThought | (raw passthrough) | — |
+
+**Known upstream, deliberately skipped:** preToolUse/postToolUse (would
+double-fire alongside the specific before*/after* hooks), beforeTabFileRead,
+afterTabFileEdit (tab completions — constant noise), workspaceOpen (no
+conversation context).
+
+## OpenCode
+
+- **Integration:** plugin at `agents/opencode/plugins/bingbong.js`, installed to `~/.config/opencode/plugins/bingbong.js`.
+- **Source of truth (open source):**
+  - https://github.com/sst/opencode/blob/dev/packages/plugin/src/index.ts (hook interface)
+  - https://github.com/sst/opencode/blob/dev/packages/schema/src/ (bus event definitions)
+  - https://opencode.ai/docs/plugins (docs; has been stale before — prefer source)
+- **Payload notes:** bus events arrive as `{ type, properties }`; session id is `properties.sessionID` (or `properties.info.id`). Tool hooks: `tool.execute.before(input: {tool, sessionID, callID}, output: {args})`, `tool.execute.after(input: {tool, sessionID, callID, args}, output: {title, output, metadata})`.
+
+| OpenCode event | Canonical type |
+|---|---|
+| tool.execute.before / after (hooks) | PreToolUse / PostToolUse |
+| session.created / session.deleted | SessionStart / SessionEnd |
+| session.idle (deprecated upstream) | Stop |
+| session.status → status.type === "idle" | Stop (deduped vs session.idle, 1.5s window) |
+| session.error | Stop |
+| session.compacted | PostCompact |
+| permission.asked | PermissionRequest |
+| everything else not ignored | raw passthrough (default blip) |
+
+**Ignored (flood control):** `message.part.*`, `session.next.*`, `lsp.*`,
+`tui.*`, `pty.*`, `installation.*`, `file.watcher.*`, `models-dev.*`,
+`catalog.*`, `server.connected`, `global.disposed`.
+
+## pi
+
+- **Integration:** extension at `agents/pi/extensions/bingbong.ts`, installed to `~/.pi/agent/extensions/bingbong.ts`.
+- **Source of truth (open source):** repo moved to https://github.com/earendil-works/pi (was badlogic/pi-mono; npm `@earendil-works/pi-coding-agent`, formerly `@mariozechner/pi-coding-agent`)
+  - `packages/coding-agent/src/core/extensions/types.ts` (`ExtensionEvent` union)
+  - `packages/coding-agent/docs/extensions.md`
+  - `packages/coding-agent/CHANGELOG.md` (breaking changes)
+- **Payload notes:** session id via `ctx.sessionManager.getSessionId()` (falls back to `getSessionFile()`); tool events carry `toolName`, `input`, `content`/`details`/`isError`. Extensions are torn down and re-created on `/new`, `/resume`, `/fork` (`session_shutdown` → `session_start` with `event.reason`).
+
+| pi event | Canonical type |
+|---|---|
+| tool_call / tool_result | PreToolUse / PostToolUse |
+| session_start / session_shutdown | SessionStart / SessionEnd |
+| session_before_compact / session_compact | PreCompact / PostCompact |
+| agent_settled, agent_end | Stop (deduped, 1.5s window) |
+| session_info_changed, session_before_switch, session_before_fork, session_before_tree, session_tree, before_agent_start, agent_start, turn_start, context, turn_end | raw passthrough |
+
+**Removed upstream (don't resubscribe):** `session_switch`, `session_branch`,
+`session_fork` — replaced by `session_start` with `reason: "new"|"resume"|"fork"`.
+
+**Known upstream, deliberately skipped:** `message_*`, `tool_execution_*`
+(redundant with tool_call/tool_result), `before_provider_*`,
+`after_provider_response`, `model_select`, `thinking_level_select`,
+`project_trust`, `resources_discover`, `user_bash`, `input`.
+
+---
+
+## Audit history
+
+| Date | Notes |
+|---|---|
+| 2026-07-19 | Initial audit. Added 8 new Claude Code hooks + 6 Cursor hooks; Cursor camelCase → canonical mapping in emit.ts; fixed OpenCode `tool.execute.after` arg shapes + `properties.sessionID` extraction + stream-event flood control; pi: dropped removed events, `session_before_branch`→`session_before_fork`, added `agent_settled`, switched to `getSessionId()`; new sounds for 12 canonical event types. |

--- a/agents/opencode/README.md
+++ b/agents/opencode/README.md
@@ -5,15 +5,20 @@ This directory contains the OpenCode plugin that emits Bingbong events.
 ## Install
 
 ```bash
-./agents/opencode/install.sh
+bingbong install-hooks opencode
 ```
 
-This installs the plugin globally to `~/.config/opencode/plugins/`.
+This installs the plugin globally to `~/.config/opencode/plugins/bingbong.js`.
 
 ## Configuration
 
-Optional environment variables:
+Optional environment variables (read by the plugin at runtime):
 
-- `BINGBONG_URL` (default: `http://localhost:3333`)
+- `BINGBONG_URL` (default: `http://localhost:3334`)
 - `BINGBONG_ENABLED` (`false` disables all events)
 - `BINGBONG_MACHINE_ID` (override hostname)
+
+## Event mapping
+
+See [docs/agents/event-coverage.md](../../docs/agents/event-coverage.md) for the
+full mapping of OpenCode bus events to Bingbong event types.

--- a/agents/opencode/README.md
+++ b/agents/opencode/README.md
@@ -20,5 +20,5 @@ Optional environment variables (read by the plugin at runtime):
 
 ## Event mapping
 
-See [docs/agents/event-coverage.md](../../docs/agents/event-coverage.md) for the
+See [agents/event-coverage.md](../../agents/event-coverage.md) for the
 full mapping of OpenCode bus events to Bingbong event types.

--- a/agents/opencode/plugins/bingbong.js
+++ b/agents/opencode/plugins/bingbong.js
@@ -11,6 +11,25 @@ const MACHINE_ID = Bun.env.BINGBONG_MACHINE_ID || os.hostname();
 
 const TOOL_EVENT_TYPES = new Set(["tool.execute.before", "tool.execute.after"]);
 
+// High-frequency / non-session bus events that would flood the soundscape.
+// message.part.* fires on every streaming delta; session.next.* is the new
+// fine-grained streaming event family.
+const IGNORED_PREFIXES = [
+  "message.part.",
+  "session.next.",
+  "lsp.",
+  "tui.",
+  "pty.",
+  "installation.",
+  "file.watcher.",
+  "models-dev.",
+  "catalog.",
+];
+const IGNORED_TYPES = new Set(["server.connected", "global.disposed"]);
+
+const shouldIgnore = (type) =>
+  IGNORED_TYPES.has(type) || IGNORED_PREFIXES.some((p) => type.startsWith(p));
+
 const nowIso = () => new Date().toISOString();
 
 const safeJson = (value) => {
@@ -22,6 +41,9 @@ const safeJson = (value) => {
 };
 
 const extractSessionId = (candidate) =>
+  candidate?.properties?.sessionID ||
+  candidate?.properties?.info?.id ||
+  candidate?.sessionID ||
   candidate?.session?.id ||
   candidate?.sessionId ||
   candidate?.session_id ||
@@ -37,11 +59,23 @@ const EVENT_TYPE_MAP = {
   "tool.execute.after": "PostToolUse",
   "session.created": "SessionStart",
   "session.deleted": "SessionEnd",
-  "session.idle": "Stop",
+  "session.idle": "Stop", // deprecated upstream in favor of session.status, still published
   "session.error": "Stop",
+  "session.compacted": "PostCompact",
+  "permission.asked": "PermissionRequest",
 };
 
 const mapEventType = (eventType) => EVENT_TYPE_MAP[eventType] || eventType;
+
+// session.idle (deprecated) and session.status{type:"idle"} are both published
+// on current OpenCode; suppress the duplicate Stop within a short window.
+const lastStopAt = new Map();
+const isDuplicateStop = (sessionId) => {
+  const now = Date.now();
+  const last = lastStopAt.get(sessionId) || 0;
+  lastStopAt.set(sessionId, now);
+  return now - last < 1500;
+};
 
 const sendEvent = async ({
   eventType,
@@ -54,6 +88,8 @@ const sendEvent = async ({
   if (!BINGBONG_ENABLED) return;
 
   const mappedEventType = mapEventType(eventType);
+  if (mappedEventType === "Stop" && isDuplicateStop(sessionId)) return;
+
   const output =
     mappedEventType === eventType
       ? toolOutput
@@ -84,7 +120,19 @@ const sendEvent = async ({
 export const BingbongPlugin = async ({ directory }) => {
   return {
     event: async ({ event }) => {
-      if (!event || TOOL_EVENT_TYPES.has(event.type)) return;
+      if (!event || TOOL_EVENT_TYPES.has(event.type) || shouldIgnore(event.type)) return;
+
+      // session.status replaces the deprecated session.idle; only the idle
+      // transition is audibly interesting.
+      if (event.type === "session.status") {
+        if (event.properties?.status?.type !== "idle") return;
+        await sendEvent({
+          eventType: "session.idle",
+          sessionId: extractSessionId(event),
+          cwd: extractCwd(event, directory),
+        });
+        return;
+      }
 
       await sendEvent({
         eventType: event.type || "unknown",
@@ -96,6 +144,7 @@ export const BingbongPlugin = async ({ directory }) => {
       });
     },
 
+    // input: { tool, sessionID, callID }, output: { args }
     "tool.execute.before": async (input, output) => {
       await sendEvent({
         eventType: "tool.execute.before",
@@ -107,14 +156,19 @@ export const BingbongPlugin = async ({ directory }) => {
       });
     },
 
+    // input: { tool, sessionID, callID, args }, output: { title, output, metadata }
     "tool.execute.after": async (input, output) => {
       await sendEvent({
         eventType: "tool.execute.after",
         sessionId: extractSessionId(input || output),
         cwd: extractCwd(output, directory),
         toolName: input?.tool || "",
-        toolInput: output?.args || {},
-        toolOutput: output?.result || output || {},
+        toolInput: input?.args || output?.args || {},
+        toolOutput: {
+          title: output?.title,
+          output: output?.output,
+          metadata: output?.metadata,
+        },
       });
     },
   };

--- a/agents/pi/README.md
+++ b/agents/pi/README.md
@@ -1,23 +1,30 @@
 # pi-coding-agent Integration
 
-This directory contains the global extension for pi-coding-agent.
+This directory contains the global extension for pi
+(`@earendil-works/pi-coding-agent`, formerly `@mariozechner/pi-coding-agent`).
 
 ## Install (global)
 
 ```bash
-./agents/pi/install.sh
+bingbong install-hooks pi
 ```
+
+This installs the extension to `~/.pi/agent/extensions/bingbong.ts`.
 
 ## Configuration
 
 The installer accepts environment variables:
 
 - `PI_EXTENSIONS_DIR` (default: `~/.pi/agent/extensions`)
-- `BINGBONG_URL` (default: `http://localhost:3333`)
-- `BINGBONG_HOST` and `BINGBONG_PORT` (used to build `BINGBONG_URL`)
+- `BINGBONG_URL` (default: `http://localhost:3334`, baked into the installed file)
 
-Example:
+At runtime the extension also reads:
 
-```bash
-BINGBONG_HOST=127.0.0.1 BINGBONG_PORT=3333 ./agents/pi/install.sh
-```
+- `BINGBONG_URL` (overrides the baked-in URL)
+- `BINGBONG_ENABLED` (`false` disables all events)
+- `BINGBONG_MACHINE_ID` (override hostname)
+
+## Event mapping
+
+See [docs/agents/event-coverage.md](../../docs/agents/event-coverage.md) for the
+full mapping of pi extension events to Bingbong event types.

--- a/agents/pi/README.md
+++ b/agents/pi/README.md
@@ -26,5 +26,5 @@ At runtime the extension also reads:
 
 ## Event mapping
 
-See [docs/agents/event-coverage.md](../../docs/agents/event-coverage.md) for the
+See [agents/event-coverage.md](../../agents/event-coverage.md) for the
 full mapping of pi extension events to Bingbong event types.

--- a/agents/pi/extensions/bingbong.ts
+++ b/agents/pi/extensions/bingbong.ts
@@ -1,4 +1,6 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+// Type-only import: erased at compile time, so this also works on older pi
+// installs that still resolve the legacy @mariozechner scope.
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import os from "node:os";
 
 const DEFAULT_URL = "http://localhost:3334";
@@ -14,6 +16,11 @@ const EVENT_TYPE_MAP: Record<string, string> = {
   tool_result: "PostToolUse",
   session_start: "SessionStart",
   session_shutdown: "SessionEnd",
+  session_before_compact: "PreCompact",
+  session_compact: "PostCompact",
+  // agent_settled is the definitive "nothing left to do" signal on current pi;
+  // agent_end is kept mapped for older versions. Duplicate Stops are deduped.
+  agent_settled: "Stop",
   agent_end: "Stop",
 };
 
@@ -30,6 +37,16 @@ const safeJson = (value: unknown) => {
 };
 
 export default function (pi: ExtensionAPI) {
+  // agent_end and agent_settled both map to Stop and fire back-to-back on
+  // current pi; suppress the duplicate within a short window.
+  let lastStopAt = 0;
+  const isDuplicateStop = () => {
+    const now = Date.now();
+    const duplicate = now - lastStopAt < 1500;
+    lastStopAt = now;
+    return duplicate;
+  };
+
   const sendEvent = async ({
     eventType,
     sessionId,
@@ -48,6 +65,8 @@ export default function (pi: ExtensionAPI) {
     if (!enabled) return;
 
     const mappedEventType = mapEventType(eventType);
+    if (mappedEventType === "Stop" && isDuplicateStop()) return;
+
     const output =
       mappedEventType === eventType
         ? toolOutput
@@ -76,7 +95,10 @@ export default function (pi: ExtensionAPI) {
   };
 
   const baseCtx = (ctx: any) => {
-    const sessionId = ctx?.sessionManager?.getSessionFile?.() || "ephemeral";
+    const sessionId =
+      ctx?.sessionManager?.getSessionId?.() ||
+      ctx?.sessionManager?.getSessionFile?.() ||
+      "ephemeral";
     const cwd = ctx?.cwd || process.cwd();
     return { sessionId, cwd };
   };
@@ -124,12 +146,14 @@ export default function (pi: ExtensionAPI) {
     });
   };
 
-  // Session events
+  // Session events. Note: pi tears down and re-instantiates extensions on
+  // /new, /resume, /fork — session_shutdown fires on the old instance, then
+  // session_start (with event.reason) on the new one. The post-transition
+  // events session_switch/session_branch/session_fork were removed upstream.
   on("session_start");
+  on("session_info_changed");
   on("session_before_switch");
-  on("session_switch");
-  on("session_before_branch");
-  on("session_branch");
+  on("session_before_fork");
   on("session_before_compact");
   on("session_compact");
   on("session_before_tree");
@@ -143,6 +167,7 @@ export default function (pi: ExtensionAPI) {
   on("context");
   on("turn_end");
   on("agent_end");
+  on("agent_settled");
 
   // Tool events
   on("tool_call");

--- a/apps/client/src/config.ts
+++ b/apps/client/src/config.ts
@@ -33,6 +33,72 @@ export const SOUND_CONFIG: Record<string, SoundParams | Record<string, SoundPara
     type: 'sawtooth',
     gain: 0.15,
   },
+  PostCompact: {
+    note: 'E4',
+    duration: 0.2,
+    type: 'sawtooth',
+    gain: 0.15,
+  },
+  SubagentStart: {
+    note: 'G4',
+    duration: 0.2,
+    type: 'triangle',
+    gain: 0.3,
+  },
+  UserPromptSubmit: {
+    note: 'C4',
+    duration: 0.06,
+    type: 'sine',
+    gain: 0.12,
+  },
+  Notification: {
+    note: 'E5',
+    duration: 0.15,
+    type: 'sine',
+    gain: 0.25,
+  },
+  PermissionRequest: {
+    notes: ['A4', 'D5'],
+    duration: 0.3,
+    type: 'triangle',
+    gain: 0.35,
+  },
+  PermissionDenied: {
+    note: 'F3',
+    duration: 0.35,
+    type: 'sawtooth',
+    gain: 0.25,
+  },
+  PostToolUseFailure: {
+    notes: ['F3', 'E3'],
+    duration: 0.35,
+    type: 'sawtooth',
+    gain: 0.3,
+  },
+  StopFailure: {
+    notes: ['G3', 'F#3'],
+    duration: 0.5,
+    type: 'sawtooth',
+    gain: 0.3,
+  },
+  TaskCreated: {
+    note: 'B4',
+    duration: 0.12,
+    type: 'triangle',
+    gain: 0.2,
+  },
+  TaskCompleted: {
+    notes: ['B4', 'E5'],
+    duration: 0.2,
+    type: 'triangle',
+    gain: 0.3,
+  },
+  TeammateIdle: {
+    note: 'A3',
+    duration: 0.3,
+    type: 'sine',
+    gain: 0.2,
+  },
 
   // Tool-specific sounds (for PreToolUse/PostToolUse)
   tools: {

--- a/packages/cli/src/emit.ts
+++ b/packages/cli/src/emit.ts
@@ -11,6 +11,29 @@
 import os from "node:os";
 import type { BingbongEvent } from "@bingbong/protocol";
 
+/**
+ * Cursor hook names (camelCase) → canonical bingbong event types.
+ * Claude Code already emits canonical PascalCase names, and the two sets
+ * never collide, so a single lookup keyed on the raw event name is safe.
+ * Unmapped events (afterAgentResponse, afterAgentThought) pass through raw.
+ */
+const CURSOR_EVENT_MAP: Record<string, { type: string; tool?: string }> = {
+  sessionStart:         { type: "SessionStart" },
+  sessionEnd:           { type: "SessionEnd" },
+  beforeShellExecution: { type: "PreToolUse", tool: "Bash" },
+  afterShellExecution:  { type: "PostToolUse", tool: "Bash" },
+  beforeMCPExecution:   { type: "PreToolUse" },   // tool_name arrives in the payload
+  afterMCPExecution:    { type: "PostToolUse" },
+  beforeReadFile:       { type: "PreToolUse", tool: "Read" },
+  afterFileEdit:        { type: "PostToolUse", tool: "Edit" },
+  beforeSubmitPrompt:   { type: "UserPromptSubmit" },
+  postToolUseFailure:   { type: "PostToolUseFailure" },
+  subagentStart:        { type: "SubagentStart" },
+  subagentStop:         { type: "SubagentStop" },
+  preCompact:           { type: "PreCompact" },
+  stop:                 { type: "Stop" },
+};
+
 export async function emit(argv: string[]): Promise<void> {
   const enabled = (process.env.BINGBONG_ENABLED || "true").toLowerCase() !== "false";
   if (!enabled) return;
@@ -53,14 +76,31 @@ export async function emit(argv: string[]): Promise<void> {
   // Normalize session_id — agents use different field names
   const sessionId = (input.session_id ?? input.conversation_id ?? input.generation_id ?? "unknown") as string;
 
+  const mapped = CURSOR_EVENT_MAP[eventType];
+
   // Spread stdin payload, overlay our fields
   const payload: BingbongEvent = {
     ...input,
-    event_type: eventType,
+    event_type: mapped?.type ?? eventType,
     session_id: sessionId,
     machine_id: process.env.BINGBONG_MACHINE_ID || os.hostname(),
     timestamp: new Date().toISOString(),
   };
+
+  if (mapped) {
+    payload.original_event_type = eventType;
+    if (!payload.tool_name && mapped.tool) payload.tool_name = mapped.tool;
+    // Surface the most useful cursor payload field as tool_input
+    if (!payload.tool_input) {
+      if (typeof input.command === "string") payload.tool_input = { command: input.command };
+      else if (typeof input.file_path === "string") payload.tool_input = { file_path: input.file_path };
+    }
+  }
+
+  // Claude Code sends tool output as `tool_response`; normalize to the protocol field
+  if (!payload.tool_output && input.tool_response && typeof input.tool_response === "object") {
+    payload.tool_output = input.tool_response as Record<string, unknown>;
+  }
 
   try {
     await fetch(`${url}/events`, {

--- a/packages/cli/src/install-hooks.ts
+++ b/packages/cli/src/install-hooks.ts
@@ -177,7 +177,7 @@ async function atomicWriteJson(filePath: string, data: object) {
 // ---------------------------------------------------------------------------
 
 // Audibly-useful subset of Claude Code hook events. The full upstream list
-// (~30 events) and the rationale for exclusions live in docs/agents/event-coverage.md.
+// (~30 events) and the rationale for exclusions live in agents/event-coverage.md.
 const CLAUDE_EVENTS: Array<{ event: string; matcher: string }> = [
   { event: "PreToolUse",         matcher: ".*" },
   { event: "PostToolUse",        matcher: ".*" },

--- a/packages/cli/src/install-hooks.ts
+++ b/packages/cli/src/install-hooks.ts
@@ -176,18 +176,28 @@ async function atomicWriteJson(filePath: string, data: object) {
 // Claude Code installer
 // ---------------------------------------------------------------------------
 
+// Audibly-useful subset of Claude Code hook events. The full upstream list
+// (~30 events) and the rationale for exclusions live in docs/agents/event-coverage.md.
 const CLAUDE_EVENTS: Array<{ event: string; matcher: string }> = [
-  { event: "PreToolUse",        matcher: ".*" },
-  { event: "PostToolUse",       matcher: ".*" },
-  { event: "SessionStart",      matcher: "" },
-  { event: "SessionEnd",        matcher: "" },
-  { event: "Stop",              matcher: "" },
-  { event: "SubagentStop",      matcher: "" },
-  { event: "PermissionRequest", matcher: "" },
-  { event: "Notification",      matcher: "" },
-  { event: "PreCompact",        matcher: "" },
-  { event: "Setup",             matcher: "" },
-  { event: "UserPromptSubmit",  matcher: "" },
+  { event: "PreToolUse",         matcher: ".*" },
+  { event: "PostToolUse",        matcher: ".*" },
+  { event: "PostToolUseFailure", matcher: ".*" },
+  { event: "SessionStart",       matcher: "" },
+  { event: "SessionEnd",         matcher: "" },
+  { event: "Stop",               matcher: "" },
+  { event: "StopFailure",        matcher: "" },
+  { event: "SubagentStart",      matcher: "" },
+  { event: "SubagentStop",       matcher: "" },
+  { event: "PermissionRequest",  matcher: "" },
+  { event: "PermissionDenied",   matcher: "" },
+  { event: "Notification",       matcher: "" },
+  { event: "PreCompact",         matcher: "" },
+  { event: "PostCompact",        matcher: "" },
+  { event: "TaskCreated",        matcher: "" },
+  { event: "TaskCompleted",      matcher: "" },
+  { event: "TeammateIdle",       matcher: "" },
+  { event: "Setup",              matcher: "" },
+  { event: "UserPromptSubmit",   matcher: "" },
 ];
 
 function isBingbongClaudeEntry(entry: any): boolean {
@@ -243,7 +253,13 @@ async function installClaude(dryRun: boolean): Promise<string> {
 // Cursor installer
 // ---------------------------------------------------------------------------
 
+// Cursor hook events (camelCase upstream names). `bingbong emit` maps these to
+// canonical bingbong event types — see CURSOR_EVENT_MAP in emit.ts.
+// Cursor's generic preToolUse/postToolUse are intentionally skipped: they overlap
+// the specific before*/after* hooks and would double-fire sounds.
 const CURSOR_EVENTS = [
+  "sessionStart",
+  "sessionEnd",
   "beforeShellExecution",
   "afterShellExecution",
   "beforeMCPExecution",
@@ -253,6 +269,10 @@ const CURSOR_EVENTS = [
   "beforeSubmitPrompt",
   "afterAgentResponse",
   "afterAgentThought",
+  "postToolUseFailure",
+  "subagentStart",
+  "subagentStop",
+  "preCompact",
   "stop",
 ];
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -7,6 +7,8 @@ export interface BingbongEvent {
   tool_name?: string;
   tool_input?: Record<string, unknown>;
   tool_output?: Record<string, unknown>;
+  /** Harness-native event name when event_type was normalized to a canonical type */
+  original_event_type?: string;
 }
 
 export interface EnrichedEvent extends BingbongEvent {


### PR DESCRIPTION
Full audit of all four harness integrations against their July 2026 upstream APIs (Claude Code + Cursor via official docs, OpenCode + pi via source).

## Claude Code
- register 8 new hook events: PostToolUseFailure, SubagentStart, PermissionDenied, PostCompact, StopFailure, TaskCreated, TaskCompleted, TeammateIdle (all 11 existing hooks remain valid)
- normalize `tool_response` (the actual upstream field) into the protocol's `tool_output`

## Cursor
- register 6 new hooks: sessionStart, sessionEnd, subagentStart, subagentStop, postToolUseFailure, preCompact
- new `CURSOR_EVENT_MAP` in `emit.ts`: cursor's camelCase names now normalize to canonical types (beforeShellExecution → PreToolUse/Bash, afterFileEdit → PostToolUse/Edit, …). previously every cursor event fell through to the default blip; now cursor sessions get real tool/session sounds

## OpenCode
- fix `tool.execute.after` arg shapes (args moved to `input`, output is now `{title, output, metadata}`)
- fix session-id extraction (`properties.sessionID` / `properties.info.id` were never read)
- handle `session.status` (replacement for deprecated `session.idle`) with a dedupe window so both firing doesn't double-chime
- ignore high-frequency stream events (`message.part.*`, `session.next.*`, lsp/tui/pty/etc.) that would flood the soundscape
- map `session.compacted` → PostCompact, `permission.asked` → PermissionRequest

## pi
- drop `session_switch` / `session_branch` (removed upstream 0.65.0 — handlers were silently dead), rename `session_before_branch` → `session_before_fork`
- subscribe `agent_settled` (the definitive done signal) with Stop dedupe vs `agent_end`
- session id via `ctx.sessionManager.getSessionId()` with `getSessionFile()` fallback
- type import from `@earendil-works/pi-coding-agent` (repo/npm moved off `@mariozechner`)

## Client
- sounds for 12 canonical event types that previously fell back to the default blip (failures get dissonant sawtooth, permissions get attention tones, etc.)

## Keeping it current
- `agents/event-coverage.md`: per-harness source-of-truth URLs, full mapping tables, deliberately-skipped events with reasons, audit history
- `.claude/skills/sync-agent-events/SKILL.md`: repeatable audit procedure (parallel research per harness → diff against matrix → guarded updates → verification steps)

Verified: client typecheck, CLI bundles, and end-to-end emit against a live server (`beforeShellExecution` + `conversation_id` arrives as `PreToolUse | session=cur-123 | tool=Bash`).