### PR TITLE
bump release actions to node24 majors

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -59,7 +59,7 @@ jobs:
           (cd dist/release && shasum -a 256 bingbong-*.tar.gz > checksums.txt)
 
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bingbong-release-bundles
           path: |
@@ -70,7 +70,7 @@ jobs:
 
       - name: Publish GitHub Release assets
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/release/bingbong-darwin-x64.tar.gz


### PR DESCRIPTION
fixes the node 20 deprecation warning. checkout v4→v7, upload-artifact v4→v7, action-gh-release v2→v3 — all node24 runtimes, no options affected by breaking changes.